### PR TITLE
feat: Send case worker ids in the response once CW profiles are created

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/cwrdapi/CaseWorkerRefCreateTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/cwrdapi/CaseWorkerRefCreateTest.java
@@ -65,7 +65,7 @@ public class CaseWorkerRefCreateTest extends AuthorizationFunctionalTest {
 
         CaseWorkerProfileCreationResponse caseWorkerProfileCreationResponse =
                 response.getBody().as(CaseWorkerProfileCreationResponse.class);
-        caseWorkerIds = new ArrayList<>(caseWorkerProfileCreationResponse.getCaseWorkerIds());
+        caseWorkerIds = caseWorkerProfileCreationResponse.getCaseWorkerIds();
         assertEquals(caseWorkersProfileCreationRequests.size(), caseWorkerIds.size());
     }
 
@@ -106,7 +106,7 @@ public class CaseWorkerRefCreateTest extends AuthorizationFunctionalTest {
 
             CaseWorkerProfileCreationResponse caseWorkerProfileCreationResponse =
                     response.getBody().as(CaseWorkerProfileCreationResponse.class);
-            caseWorkerIds = new ArrayList<>(caseWorkerProfileCreationResponse.getCaseWorkerIds());
+            caseWorkerIds = caseWorkerProfileCreationResponse.getCaseWorkerIds();
             assertEquals(caseWorkersProfileCreationRequests.size(), caseWorkerIds.size());
         }
         Response fetchResponse = caseWorkerApiClient.getMultipleAuthHeadersInternal("cwd-admin")
@@ -146,7 +146,7 @@ public class CaseWorkerRefCreateTest extends AuthorizationFunctionalTest {
     public void shouldGetOnlyFewCaseWorkerDetails() throws Exception {
         if (caseWorkerIds.isEmpty()) {
             List<CaseWorkersProfileCreationRequest> caseWorkersProfileCreationRequests =
-                    new ArrayList<>(caseWorkerApiClient.createCaseWorkerProfiles());
+                    caseWorkerApiClient.createCaseWorkerProfiles();
 
             Response response = caseWorkerApiClient.getMultipleAuthHeadersInternal("cwd-admin")
                     .body(caseWorkersProfileCreationRequests)
@@ -158,7 +158,7 @@ public class CaseWorkerRefCreateTest extends AuthorizationFunctionalTest {
 
             CaseWorkerProfileCreationResponse caseWorkerProfileCreationResponse =
                     response.getBody().as(CaseWorkerProfileCreationResponse.class);
-            caseWorkerIds = new ArrayList<>(caseWorkerProfileCreationResponse.getCaseWorkerIds());
+            caseWorkerIds = caseWorkerProfileCreationResponse.getCaseWorkerIds();
         }
         List<String> tempCwIds = new ArrayList<>(caseWorkerIds);
         tempCwIds.add("randomId");

--- a/src/functionalTest/java/uk/gov/hmcts/reform/cwrdapi/CaseWorkerRefCreateTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/cwrdapi/CaseWorkerRefCreateTest.java
@@ -15,9 +15,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import uk.gov.hmcts.reform.cwrdapi.client.FuncTestRequestHandler;
-import uk.gov.hmcts.reform.cwrdapi.client.response.UserProfileResponse;
 import uk.gov.hmcts.reform.cwrdapi.controllers.request.CaseWorkersProfileCreationRequest;
 import uk.gov.hmcts.reform.cwrdapi.controllers.request.UserRequest;
+import uk.gov.hmcts.reform.cwrdapi.controllers.response.CaseWorkerProfileCreationResponse;
 import uk.gov.hmcts.reform.cwrdapi.util.CustomSerenityRunner;
 import uk.gov.hmcts.reform.cwrdapi.util.FeatureConditionEvaluation;
 import uk.gov.hmcts.reform.cwrdapi.util.ToggleEnable;
@@ -61,6 +61,11 @@ public class CaseWorkerRefCreateTest extends AuthorizationFunctionalTest {
         response.then()
                 .assertThat()
                 .statusCode(201);
+
+        CaseWorkerProfileCreationResponse caseWorkerProfileCreationResponse =
+                response.getBody().as(CaseWorkerProfileCreationResponse.class);
+        List<String> caseWorkerIds = new ArrayList<>(caseWorkerProfileCreationResponse.getCaseWorkerIds());
+        assertEquals(caseWorkersProfileCreationRequests.size(), caseWorkerIds.size());
     }
 
     @Test
@@ -89,8 +94,6 @@ public class CaseWorkerRefCreateTest extends AuthorizationFunctionalTest {
         caseWorkersProfileCreationRequests.addAll(caseWorkerApiClient
                 .createCaseWorkerProfiles());
 
-        List<String> caseWorkerIds = new ArrayList<>();
-
         Response response = caseWorkerApiClient.getMultipleAuthHeadersInternal("cwd-admin")
                 .body(caseWorkersProfileCreationRequests)
                 .post("/refdata/case-worker/users/")
@@ -99,17 +102,9 @@ public class CaseWorkerRefCreateTest extends AuthorizationFunctionalTest {
                 .assertThat()
                 .statusCode(201);
 
-        for (CaseWorkersProfileCreationRequest request : caseWorkersProfileCreationRequests) {
-            UserProfileResponse resource =
-                    testRequestHandler.sendGet(HttpStatus.OK,
-                            "?email=" + request.getEmailId(),
-                            UserProfileResponse.class, userProfUrl + "/v1/userprofile"
-                    );
-
-            caseWorkerIds.add(resource.getIdamId());
-
-        }
-
+        CaseWorkerProfileCreationResponse caseWorkerProfileCreationResponse =
+                response.getBody().as(CaseWorkerProfileCreationResponse.class);
+        List<String> caseWorkerIds = new ArrayList<>(caseWorkerProfileCreationResponse.getCaseWorkerIds());
         assertEquals(2, caseWorkerIds.size());
         Response fetchResponse = caseWorkerApiClient.getMultipleAuthHeadersInternal("cwd-admin")
                 .body(UserRequest.builder().userIds(caseWorkerIds).build())
@@ -150,8 +145,6 @@ public class CaseWorkerRefCreateTest extends AuthorizationFunctionalTest {
         List<CaseWorkersProfileCreationRequest> caseWorkersProfileCreationRequests = new ArrayList<>(caseWorkerApiClient
                 .createCaseWorkerProfiles());
 
-        List<String> caseWorkerIds = new ArrayList<>();
-
         Response response = caseWorkerApiClient.getMultipleAuthHeadersInternal("cwd-admin")
                 .body(caseWorkersProfileCreationRequests)
                 .post("/refdata/case-worker/users/")
@@ -160,16 +153,9 @@ public class CaseWorkerRefCreateTest extends AuthorizationFunctionalTest {
                 .assertThat()
                 .statusCode(201);
 
-        for (CaseWorkersProfileCreationRequest request : caseWorkersProfileCreationRequests) {
-            UserProfileResponse resource =
-                    testRequestHandler.sendGet(HttpStatus.OK,
-                            "?email=" + request.getEmailId(),
-                            UserProfileResponse.class, userProfUrl + "/v1/userprofile"
-                    );
-
-            caseWorkerIds.add(resource.getIdamId());
-
-        }
+        CaseWorkerProfileCreationResponse caseWorkerProfileCreationResponse =
+                response.getBody().as(CaseWorkerProfileCreationResponse.class);
+        List<String> caseWorkerIds = new ArrayList<>(caseWorkerProfileCreationResponse.getCaseWorkerIds());
         caseWorkerIds.add("randomId");
 
         assertEquals(2, caseWorkerIds.size());

--- a/src/functionalTest/java/uk/gov/hmcts/reform/cwrdapi/CaseWorkerRefCreateTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/cwrdapi/CaseWorkerRefCreateTest.java
@@ -65,7 +65,7 @@ public class CaseWorkerRefCreateTest extends AuthorizationFunctionalTest {
 
         CaseWorkerProfileCreationResponse caseWorkerProfileCreationResponse =
                 response.getBody().as(CaseWorkerProfileCreationResponse.class);
-        List<String> caseWorkerIds = new ArrayList<>(caseWorkerProfileCreationResponse.getCaseWorkerIds());
+        caseWorkerIds = new ArrayList<>(caseWorkerProfileCreationResponse.getCaseWorkerIds());
         assertEquals(caseWorkersProfileCreationRequests.size(), caseWorkerIds.size());
     }
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/cwrdapi/CaseWorkerRefCreateTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/cwrdapi/CaseWorkerRefCreateTest.java
@@ -51,7 +51,7 @@ public class CaseWorkerRefCreateTest extends AuthorizationFunctionalTest {
 
     @Test
     @ToggleEnable(mapKey = CREATE_CASEWORKER_PROFILE, withFeature = true)
-    public void whenUserNotExistsInCwrAndSidamAndUp_Ac1() {
+    public void whenUserNotExistsInCrdAndSidamAndUp_Ac1() {
         List<CaseWorkersProfileCreationRequest> caseWorkersProfileCreationRequests = caseWorkerApiClient
                 .createCaseWorkerProfiles();
 

--- a/src/main/java/uk/gov/hmcts/reform/cwrdapi/controllers/CaseWorkerRefController.java
+++ b/src/main/java/uk/gov/hmcts/reform/cwrdapi/controllers/CaseWorkerRefController.java
@@ -158,8 +158,8 @@ public class CaseWorkerRefController {
                     .map(CaseWorkerProfile::getCaseWorkerId)
                     .collect(Collectors.toUnmodifiableList());
             caseWorkerProfileCreationResponse
-                            .caseWorkerRegistrationResponse("Case Worker Profiles Created")
-                            .caseWorkerIds(caseWorkerIds);
+                    .caseWorkerRegistrationResponse("Case Worker Profiles Created")
+                    .caseWorkerIds(caseWorkerIds);
         }
         return ResponseEntity
                 .status(201)

--- a/src/main/java/uk/gov/hmcts/reform/cwrdapi/controllers/CaseWorkerRefController.java
+++ b/src/main/java/uk/gov/hmcts/reform/cwrdapi/controllers/CaseWorkerRefController.java
@@ -30,6 +30,7 @@ import uk.gov.hmcts.reform.cwrdapi.service.ExcelValidatorService;
 import uk.gov.hmcts.reform.cwrdapi.util.CaseWorkerConstants;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static uk.gov.hmcts.reform.cwrdapi.util.CaseWorkerConstants.BAD_REQUEST;
@@ -145,15 +146,24 @@ public class CaseWorkerRefController {
             throw new InvalidRequestException("Caseworker Profiles Request is empty");
         }
 
+        CaseWorkerProfileCreationResponse.CaseWorkerProfileCreationResponseBuilder caseWorkerProfileCreationResponse =
+                CaseWorkerProfileCreationResponse
+                        .builder();
         List<CaseWorkerProfile> processedCwProfiles =
                 caseWorkerService.processCaseWorkerProfiles(caseWorkersProfileCreationRequest);
 
         if (!processedCwProfiles.isEmpty()) {
             caseWorkerService.publishCaseWorkerDataToTopic(processedCwProfiles);
+            List<String> caseWorkerIds = processedCwProfiles.stream()
+                    .map(CaseWorkerProfile::getCaseWorkerId)
+                    .collect(Collectors.toUnmodifiableList());
+            caseWorkerProfileCreationResponse
+                            .caseWorkerRegistrationResponse("Case Worker Profiles Created")
+                            .caseWorkerIds(caseWorkerIds);
         }
         return ResponseEntity
                 .status(201)
-                .body(new CaseWorkerProfileCreationResponse("Case Worker Profiles Created."));
+                .body(caseWorkerProfileCreationResponse.build());
     }
 
     @ApiOperation(

--- a/src/main/java/uk/gov/hmcts/reform/cwrdapi/controllers/response/CaseWorkerProfileCreationResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/cwrdapi/controllers/response/CaseWorkerProfileCreationResponse.java
@@ -1,17 +1,22 @@
 package uk.gov.hmcts.reform.cwrdapi.controllers.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.List;
+
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class CaseWorkerProfileCreationResponse {
-
+    @JsonProperty("message")
     private String caseWorkerRegistrationResponse;
-
-    public CaseWorkerProfileCreationResponse(String caseWorkerRegistrationResponse) {
-        this.caseWorkerRegistrationResponse = caseWorkerRegistrationResponse;
-    }
+    @JsonProperty("case_worker_ids")
+    private List<String> caseWorkerIds;
 }

--- a/src/test/java/uk/gov/hmcts/reform/cwrdapi/controllers/CaseWorkerRefControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/cwrdapi/controllers/CaseWorkerRefControllerTest.java
@@ -66,7 +66,8 @@ public class CaseWorkerRefControllerTest {
     @Before
     public void setUp() throws Exception {
         caseWorkerServiceMock = mock(CaseWorkerService.class);
-        cwResponse = new CaseWorkerProfileCreationResponse("Case Worker Profiles Created.");
+        cwResponse = new CaseWorkerProfileCreationResponse("Case Worker Profiles Created.",
+                Collections.emptyList());
         responseEntity = new ResponseEntity<>(
                 cwResponse,
                 null,
@@ -94,7 +95,7 @@ public class CaseWorkerRefControllerTest {
                 "lastName","test@gmail.com",1,"userType","region",
                 false,roles,caseWorkerRoleRequests,caseWorkeLocationRequests,caseWorkeAreaRequests);
         caseWorkersProfileCreationRequest.add(cwRequest);
-        cwProfileCreationResponse = new CaseWorkerProfileCreationResponse("");
+        cwProfileCreationResponse = new CaseWorkerProfileCreationResponse("", Collections.emptyList());
         MockitoAnnotations.openMocks(this);
 
     }

--- a/src/test/java/uk/gov/hmcts/reform/cwrdapi/controllers/CaseWorkerRefControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/cwrdapi/controllers/CaseWorkerRefControllerTest.java
@@ -66,8 +66,11 @@ public class CaseWorkerRefControllerTest {
     @Before
     public void setUp() throws Exception {
         caseWorkerServiceMock = mock(CaseWorkerService.class);
-        cwResponse = new CaseWorkerProfileCreationResponse("Case Worker Profiles Created.",
-                Collections.emptyList());
+        cwResponse = CaseWorkerProfileCreationResponse
+                .builder()
+                .caseWorkerRegistrationResponse("Case Worker Profiles Created.")
+                .caseWorkerIds(Collections.emptyList())
+                .build();
         responseEntity = new ResponseEntity<>(
                 cwResponse,
                 null,
@@ -95,7 +98,11 @@ public class CaseWorkerRefControllerTest {
                 "lastName","test@gmail.com",1,"userType","region",
                 false,roles,caseWorkerRoleRequests,caseWorkeLocationRequests,caseWorkeAreaRequests);
         caseWorkersProfileCreationRequest.add(cwRequest);
-        cwProfileCreationResponse = new CaseWorkerProfileCreationResponse("", Collections.emptyList());
+        cwProfileCreationResponse = CaseWorkerProfileCreationResponse
+                .builder()
+                .caseWorkerRegistrationResponse("")
+                .caseWorkerIds(Collections.emptyList())
+                .build();
         MockitoAnnotations.openMocks(this);
 
     }

--- a/src/test/java/uk/gov/hmcts/reform/cwrdapi/controllers/response/CaseWorkerProfileCreationResponseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/cwrdapi/controllers/response/CaseWorkerProfileCreationResponseTest.java
@@ -2,12 +2,17 @@ package uk.gov.hmcts.reform.cwrdapi.controllers.response;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CaseWorkerProfileCreationResponseTest {
 
     @Test
     public void test_has_mandatory_fields_specified_not_null() {
+        List<String> ids = new ArrayList<>();
+        ids.add("1234");
         CaseWorkerProfileCreationResponse response = new CaseWorkerProfileCreationResponse();
         response.setCaseWorkerRegistrationResponse("response");
 
@@ -15,9 +20,10 @@ public class CaseWorkerProfileCreationResponseTest {
         assertThat(response.getCaseWorkerRegistrationResponse()).isEqualTo("response");
 
         CaseWorkerProfileCreationResponse response1 =
-                new CaseWorkerProfileCreationResponse("response");
+                new CaseWorkerProfileCreationResponse("response", ids);
         assertThat(response1).isNotNull();
         assertThat(response1.getCaseWorkerRegistrationResponse()).isEqualTo("response");
+        assertThat(response1.getCaseWorkerIds().get(0)).isEqualTo("1234");
     }
 }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-2207

### Change description ###

Send case worker ids in the response once CW profiles are created

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
