### PR TITLE
fix: RDCC-2436 Refactored code by removing unwanted codes and renamed methods

### DIFF
--- a/src/integrationTest/resources/application-test.yml
+++ b/src/integrationTest/resources/application-test.yml
@@ -18,12 +18,12 @@ spring:
     show-sql: false
     properties:
       hibernate:
+        order_updates: true
+        order_inserts: true
         jdbc:
           lob:
             non_contextual_creation: true
           batch_size: 10
-          order_updates: true
-          order_inserts: true
   main:
     allow-bean-definition-overriding: true
   application:

--- a/src/main/java/uk/gov/hmcts/reform/cwrdapi/controllers/CaseWorkerRefController.java
+++ b/src/main/java/uk/gov/hmcts/reform/cwrdapi/controllers/CaseWorkerRefController.java
@@ -150,8 +150,7 @@ public class CaseWorkerRefController {
 
         CaseWorkerProfileCreationResponse.CaseWorkerProfileCreationResponseBuilder caseWorkerProfileCreationResponse =
                 CaseWorkerProfileCreationResponse
-                        .builder()
-                        .caseWorkerRegistrationResponse(REQUEST_COMPLETED_SUCCESSFULLY);
+                        .builder();
 
         trimIdamRoles(caseWorkersProfileCreationRequest);
         long time1 = System.currentTimeMillis();
@@ -167,7 +166,9 @@ public class CaseWorkerRefController {
             List<String> caseWorkerIds = processedCwProfiles.stream()
                     .map(CaseWorkerProfile::getCaseWorkerId)
                     .collect(Collectors.toUnmodifiableList());
+
             caseWorkerProfileCreationResponse
+                    .caseWorkerRegistrationResponse(REQUEST_COMPLETED_SUCCESSFULLY)
                     .messageDetails(format(RECORDS_UPLOADED, caseWorkerIds.size()))
                     .caseWorkerIds(caseWorkerIds);
         }

--- a/src/main/java/uk/gov/hmcts/reform/cwrdapi/service/impl/CaseWorkerServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/cwrdapi/service/impl/CaseWorkerServiceImpl.java
@@ -173,12 +173,12 @@ public class CaseWorkerServiceImpl implements CaseWorkerService {
                     //when existing profile with delete flag is true in request then suspend user
                     UserProfileUpdatedData usrProfileStatusUpdate = UserProfileUpdatedData.builder()
                         .idamStatus(IDAM_STATUS_SUSPENDED).build();
-                    if (modifyCaseWorkerUserStatus(usrProfileStatusUpdate, caseWorkerProfile.getCaseWorkerId(),
+                    if (isUserSuspended(usrProfileStatusUpdate, caseWorkerProfile.getCaseWorkerId(),
                         ORIGIN_EXUI, cwrRequest.getRowId())) {
                         caseWorkerProfile.setSuspended(true);
                         newCaseWorkerProfiles.add(caseWorkerProfile);
                     }
-                } else if (isNotTrue(caseWorkerProfile.getSuspended())) {
+                } else {
                     //when existing profile with delete flag is false then update user in CRD db and roles in SIDAM
                     requestMap.put(caseWorkerProfile.getEmailId(), cwrRequest);
                     updateCaseWorkerProfiles.add(caseWorkerProfile);
@@ -458,7 +458,7 @@ public class CaseWorkerServiceImpl implements CaseWorkerService {
                 if (isNotEmpty(mergedRoles)) {
                     UserProfileUpdatedData usrProfileStatusUpdate = UserProfileUpdatedData.builder()
                         .rolesAdd(mergedRoles).build();
-                    return modifyCaseWorkerUser(usrProfileStatusUpdate, idamId, "EXUI",
+                    return isEachRoleUpdated(usrProfileStatusUpdate, idamId, "EXUI",
                         cwrProfileRequest.getRowId());
                 }
             }
@@ -541,18 +541,12 @@ public class CaseWorkerServiceImpl implements CaseWorkerService {
     }
 
 
-    public boolean modifyCaseWorkerUserStatus(UserProfileUpdatedData userProfileUpdatedData, String userId,
-                                              String origin, long rowId) {
+    public boolean isUserSuspended(UserProfileUpdatedData userProfileUpdatedData, String userId,
+                                   String origin, long rowId) {
 
         boolean status = true;
         try {
-            Response response = userProfileFeignClient.modifyUserRoles(userProfileUpdatedData, userId, origin);
-            log.info("{}:: UserProfile update roles :: status code {} ", loggingComponentName, response.status());
-
-            ResponseEntity<Object> responseEntity = toResponseEntity(response, UserProfileRolesResponse.class);
-
-            Optional<Object> resultResponse = validateAndGetResponseEntity(responseEntity);
-
+            Optional<Object> resultResponse = getUserProfileUpdateResponse(userProfileUpdatedData, userId, origin);
 
             if (!resultResponse.isPresent()
                 || (isNull(((UserProfileRolesResponse) resultResponse.get())
@@ -572,15 +566,10 @@ public class CaseWorkerServiceImpl implements CaseWorkerService {
         return status;
     }
 
-    public boolean modifyCaseWorkerUser(UserProfileUpdatedData userProfileUpdatedData, String userId,
-                                        String origin, long rowId) {
+    public boolean isEachRoleUpdated(UserProfileUpdatedData userProfileUpdatedData, String userId,
+                                     String origin, long rowId) {
         try {
-            Response response = userProfileFeignClient.modifyUserRoles(userProfileUpdatedData, userId, origin);
-            log.info("{}:: UserProfile update roles :: status code {} ", loggingComponentName, response.status());
-
-            ResponseEntity<Object> responseEntity = toResponseEntity(response, UserProfileRolesResponse.class);
-
-            Optional<Object> resultResponse = validateAndGetResponseEntity(responseEntity);
+            Optional<Object> resultResponse = getUserProfileUpdateResponse(userProfileUpdatedData, userId, origin);
 
             if (!resultResponse.isPresent()
                 || (isNull(((UserProfileRolesResponse) resultResponse.get())
@@ -598,6 +587,16 @@ public class CaseWorkerServiceImpl implements CaseWorkerService {
             return false;
         }
         return true;
+    }
+
+    private Optional<Object> getUserProfileUpdateResponse(UserProfileUpdatedData userProfileUpdatedData,
+                                                          String userId, String origin) {
+        Response response = userProfileFeignClient.modifyUserRoles(userProfileUpdatedData, userId, origin);
+        log.info("{}:: UserProfile update roles :: status code {} ", loggingComponentName, response.status());
+
+        ResponseEntity<Object> responseEntity = toResponseEntity(response, UserProfileRolesResponse.class);
+
+        return validateAndGetResponseEntity(responseEntity);
     }
 
     // creating user profile request

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,8 +21,9 @@ spring:
         jdbc:
           lob:
             non_contextual_creation: true
-          batch_size: 5
+          batch_size: 20
           order_inserts: true
+          order_updates: true
   application:
     name: RD Caseworker Ref API
   main:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,12 +18,12 @@ spring:
     show-sql: true
     properties:
       hibernate:
+        order_updates: true
+        order_inserts: true
         jdbc:
           lob:
             non_contextual_creation: true
           batch_size: 20
-          order_inserts: true
-          order_updates: true
   application:
     name: RD Caseworker Ref API
   main:


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-2436

### Change description ###
This PR addresses the below review comments

- This check seems to be redundant and can be removed
if (workbook.getNumberOfSheets() < 1) { // check at least 1 sheet present throw new ExcelValidationException(HttpStatus.BAD_REQUEST, FILE_NO_DATA_ERROR_MESSAGE); }

- The following code should be inside the if condition — > if (isNotEmpty(processedCwProfiles)) {
CaseWorkerProfileCreationResponse.CaseWorkerProfileCreationResponseBuilder caseWorkerProfileCreationResponse =
CaseWorkerProfileCreationResponse
.builder()
.caseWorkerRegistrationResponse(REQUEST_COMPLETED_SUCCESSFULLY);

- modifyCaseWorkerUserStatus() And modifyCaseWorkerUser() methods look same. One of them can be removed.

- Set hibernate.order_updates to true

- Set batch_size to 20


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
