### PR TITLE
fix: RDCC-2436 Removed redundant code and fixed CVE CVE-2021-22112

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
     id "info.solidsoft.pitest" version '1.5.2'
     id 'io.spring.dependency-management' version '1.0.10.RELEASE'
     id 'org.sonarqube' version '3.1.1'
-    id 'org.springframework.boot' version '2.3.4.RELEASE'
+    id 'org.springframework.boot' version '2.3.9.RELEASE'
     id "org.flywaydb.flyway" version "7.0.2"
     id 'au.com.dius.pact' version '4.1.7'
 }
@@ -35,7 +35,7 @@ def versions = [
   reformS2sClient    : '3.1.2',
   serenity           : '2.0.76',
   sonarPitest        : '0.5',
-  springBoot         : '2.3.4.RELEASE',
+  springBoot         : '2.3.9.RELEASE',
   springHystrix      : '2.1.1.RELEASE',
   springfoxSwagger   : '2.9.2',
   pact_version       : '4.1.7',

--- a/src/main/java/uk/gov/hmcts/reform/cwrdapi/service/impl/ExcelAdaptorServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/cwrdapi/service/impl/ExcelAdaptorServiceImpl.java
@@ -70,9 +70,6 @@ public class ExcelAdaptorServiceImpl implements ExcelAdaptorService {
     public <T> List<T> parseExcel(Workbook workbook, Class<T> classType) {
         evaluator = workbook.getCreationHelper().createFormulaEvaluator();
         List<String> validHeaders;
-        if (workbook.getNumberOfSheets() < 1) { // check at least 1 sheet present
-            throw new ExcelValidationException(HttpStatus.BAD_REQUEST, FILE_NO_DATA_ERROR_MESSAGE);
-        }
         Sheet sheet;
         if (classType.isAssignableFrom(CaseWorkerProfile.class)) {
             sheet = workbook.getSheet(REQUIRED_CW_SHEET_NAME);


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/RDCC-2436


### Change description ###
Fixed the below review comment 

- 1. This check seems to be redundant and can be removed
if (workbook.getNumberOfSheets() < 1) { // check at least 1 sheet present throw new ExcelValidationException(HttpStatus.BAD_REQUEST, FILE_NO_DATA_ERROR_MESSAGE); }

and 

- fixed CVE-2021-22112 by upgrading springboot version


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
