### PR TITLE
fix: RDCC-2478 Avoided to create audit for user with invalid role

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/cwrdapi/CaseWorkerCreateUserWithFileUploadTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/cwrdapi/CaseWorkerCreateUserWithFileUploadTest.java
@@ -470,6 +470,7 @@ public class CaseWorkerCreateUserWithFileUploadTest extends FileUploadTest {
         List<CaseWorkerAudit> caseWorkerAudits = caseWorkerAuditRepository.findAll();
         assertThat(caseWorkerAudits.size()).isZero();
         CaseWorkerReferenceDataClient.setBearerToken(EMPTY);
+
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/cwrdapi/CaseWorkerCreateUserWithFileUploadTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/cwrdapi/CaseWorkerCreateUserWithFileUploadTest.java
@@ -470,7 +470,6 @@ public class CaseWorkerCreateUserWithFileUploadTest extends FileUploadTest {
         List<CaseWorkerAudit> caseWorkerAudits = caseWorkerAuditRepository.findAll();
         assertThat(caseWorkerAudits.size()).isZero();
         CaseWorkerReferenceDataClient.setBearerToken(EMPTY);
-
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/cwrdapi/util/AuditInterceptor.java
+++ b/src/main/java/uk/gov/hmcts/reform/cwrdapi/util/AuditInterceptor.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
@@ -45,6 +46,7 @@ public class AuditInterceptor implements HandlerInterceptor {
     private String loggingComponentName;
 
     @Override
+    @Secured("cwd-admin")
     public boolean preHandle(HttpServletRequest request,
                              @NotNull HttpServletResponse response, @NotNull Object handler) {
 


### PR DESCRIPTION
### JIRA link  ###

https://tools.hmcts.net/jira/browse/RDCC-2478

### Change description ###
Scenario to reproduce the issue mentioned in the ticket

- Create a user with invalid role
- Upload a file.
- For the same user add role "cwd-admin".
- Upload the same file


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
