### PR TITLE
RDCC-2478: Avoided to create audit for user with invalid role

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/cwrdapi/CaseWorkerCreateUserWithFileUploadTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/cwrdapi/CaseWorkerCreateUserWithFileUploadTest.java
@@ -11,11 +11,13 @@ import uk.gov.hmcts.reform.cwrdapi.controllers.response.CaseWorkerFileCreationRe
 import uk.gov.hmcts.reform.cwrdapi.controllers.response.JsrFileErrors;
 import uk.gov.hmcts.reform.cwrdapi.domain.CaseWorkerAudit;
 import uk.gov.hmcts.reform.cwrdapi.domain.CaseWorkerIdamRoleAssociation;
+import uk.gov.hmcts.reform.cwrdapi.domain.CaseWorkerProfile;
 import uk.gov.hmcts.reform.cwrdapi.domain.ExceptionCaseWorker;
 import uk.gov.hmcts.reform.cwrdapi.util.CaseWorkerConstants;
 import uk.gov.hmcts.reform.cwrdapi.util.CaseWorkerReferenceDataClient;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -73,10 +75,13 @@ public class CaseWorkerCreateUserWithFileUploadTest extends FileUploadTest {
     @Test
     public void shouldUploadCaseWorkerUsersXlsxFileSuccessfully() throws IOException {
         uploadCaseWorkerFile("Staff Data Upload.xlsx",
-            TYPE_XLSX, "200 OK", cwdAdmin);
+                TYPE_XLSX, "200 OK", cwdAdmin);
+        CaseWorkerProfile caseWorkerProfile = caseWorkerProfileRepository.findAll().get(0);
+        int totalZoneSecondsFromUtc = caseWorkerProfile.getCreatedDate().atZone(ZoneId.of("Europe/London")).getOffset()
+                .getTotalSeconds();
         //to check UTC time is persisted in db
-        assertThat(caseWorkerProfileRepository.findAll().get(0).getCreatedDate())
-                .isCloseToUtcNow(within(10, SECONDS));
+        assertThat(caseWorkerProfile.getCreatedDate())
+                .isCloseToUtcNow(within(totalZoneSecondsFromUtc + 10, SECONDS));
     }
 
     @Test
@@ -454,6 +459,17 @@ public class CaseWorkerCreateUserWithFileUploadTest extends FileUploadTest {
         assertThat(exceptionCaseWorkers.size()).isEqualTo(2);
         assertEquals(format(DUPLICATE_EMAIL_PROFILES, 3), exceptionCaseWorkers.get(0).getErrorDescription());
         assertEquals(format(DUPLICATE_EMAIL_PROFILES, 4), exceptionCaseWorkers.get(1).getErrorDescription());
+    }
+
+    @Test
+    public void shouldFailToCreateAuditForInvalidRole() throws IOException {
+        CaseWorkerReferenceDataClient.setBearerToken(EMPTY);
+        uploadCaseWorkerFile("Staff Data Upload.xlsx",
+                        TYPE_XLSX, "403", "invalid");
+
+        List<CaseWorkerAudit> caseWorkerAudits = caseWorkerAuditRepository.findAll();
+        assertThat(caseWorkerAudits.size()).isZero();
+        CaseWorkerReferenceDataClient.setBearerToken(EMPTY);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/cwrdapi/util/AuditInterceptor.java
+++ b/src/main/java/uk/gov/hmcts/reform/cwrdapi/util/AuditInterceptor.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
@@ -45,6 +46,7 @@ public class AuditInterceptor implements HandlerInterceptor {
     private String loggingComponentName;
 
     @Override
+    @Secured("cwd-admin")
     public boolean preHandle(HttpServletRequest request,
                              @NotNull HttpServletResponse response, @NotNull Object handler) {
 


### PR DESCRIPTION
JIRA link
https://tools.hmcts.net/jira/browse/RDCC-2478

Change description
Scenario to reproduce the issue mentioned in the ticket

Create a user with invalid role
Upload a file.
For the same user add role "cwd-admin".
Upload the same file
Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[x] No