### PR TITLE
Upgrade the Netty Jar to fix CVE-2021-21409

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -357,44 +357,44 @@ dependencies {
   implementation group: 'com.azure', name: 'azure-core', version: '1.13.0'
   implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.0.2'
   implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
-  implementation('io.netty:netty-buffer:4.1.60.Final') {
-    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
+  implementation('io.netty:netty-buffer:4.1.63.Final') {
+    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
   }
-  implementation('io.netty:netty-codec:4.1.60.Final') {
-    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
+  implementation('io.netty:netty-codec:4.1.63.Final') {
+    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
   }
-  implementation('io.netty:netty-codec-http:4.1.60.Final') {
-    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
+  implementation('io.netty:netty-codec-http:4.1.63.Final') {
+    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
   }
-  implementation('io.netty:netty-common:4.1.60.Final') {
-    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
+  implementation('io.netty:netty-common:4.1.63.Final') {
+    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
   }
-  implementation('io.netty:netty-handler:4.1.60.Final') {
-    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
+  implementation('io.netty:netty-handler:4.1.63.Final') {
+    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
   }
-  implementation('io.netty:netty-resolver:4.1.60.Final') {
-    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
+  implementation('io.netty:netty-resolver:4.1.63.Final') {
+    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
   }
-  implementation('io.netty:netty-transport:4.1.60.Final') {
-    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
+  implementation('io.netty:netty-transport:4.1.63.Final') {
+    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
   }
-  implementation('io.netty:netty-transport-native-epoll:4.1.60.Final') {
-    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
+  implementation('io.netty:netty-transport-native-epoll:4.1.63.Final') {
+    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
   }
-  implementation('io.netty:netty-transport-native-kqueue:4.1.60.Final') {
-    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
+  implementation('io.netty:netty-transport-native-kqueue:4.1.63.Final') {
+    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
   }
-  implementation('io.netty:netty-transport-native-unix-common:4.1.60.Final') {
-    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
+  implementation('io.netty:netty-transport-native-unix-common:4.1.63.Final') {
+    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
   }
-  implementation('io.netty:netty-codec-http2:4.1.60.Final') {
-    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
+  implementation('io.netty:netty-codec-http2:4.1.63.Final') {
+    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
   }
-  implementation('io.netty:netty-codec-socks:4.1.60.Final') {
-    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
+  implementation('io.netty:netty-codec-socks:4.1.63.Final') {
+    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
   }
-  implementation('io.netty:netty-handler-proxy:4.1.60.Final') {
-    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
+  implementation('io.netty:netty-handler-proxy:4.1.63.Final') {
+    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
   }
   compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok

--- a/build.gradle
+++ b/build.gradle
@@ -358,43 +358,43 @@ dependencies {
   implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.0.2'
   implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
   implementation('io.netty:netty-buffer:4.1.63.Final') {
-    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
+    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
   }
   implementation('io.netty:netty-codec:4.1.63.Final') {
-    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
+    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
   }
   implementation('io.netty:netty-codec-http:4.1.63.Final') {
-    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
+    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
   }
   implementation('io.netty:netty-common:4.1.63.Final') {
-    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
+    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
   }
   implementation('io.netty:netty-handler:4.1.63.Final') {
-    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
+    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
   }
   implementation('io.netty:netty-resolver:4.1.63.Final') {
-    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
+    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
   }
   implementation('io.netty:netty-transport:4.1.63.Final') {
-    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
+    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
   }
   implementation('io.netty:netty-transport-native-epoll:4.1.63.Final') {
-    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
+    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
   }
   implementation('io.netty:netty-transport-native-kqueue:4.1.63.Final') {
-    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
+    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
   }
   implementation('io.netty:netty-transport-native-unix-common:4.1.63.Final') {
-    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
+    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
   }
   implementation('io.netty:netty-codec-http2:4.1.63.Final') {
-    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
+    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
   }
   implementation('io.netty:netty-codec-socks:4.1.63.Final') {
-    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
+    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
   }
   implementation('io.netty:netty-handler-proxy:4.1.63.Final') {
-    because 'In Netty before version 4.1.63.Final there is a vulnerability that enables request smuggling.'
+    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
   }
   compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok

--- a/src/integrationTest/java/uk/gov/hmcts/reform/cwrdapi/util/AuthorizationEnabledIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/cwrdapi/util/AuthorizationEnabledIntegrationTest.java
@@ -106,7 +106,6 @@ public abstract class AuthorizationEnabledIntegrationTest extends SpringBootInte
     @Autowired
     Flyway flyway;
 
-
     @Before
     public void setUpClient() {
         when(featureToggleServiceImpl.isFlagEnabled(anyString(), anyString())).thenReturn(true);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/cwrdapi/util/AuthorizationEnabledIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/cwrdapi/util/AuthorizationEnabledIntegrationTest.java
@@ -106,6 +106,7 @@ public abstract class AuthorizationEnabledIntegrationTest extends SpringBootInte
     @Autowired
     Flyway flyway;
 
+
     @Before
     public void setUpClient() {
         when(featureToggleServiceImpl.isFlagEnabled(anyString(), anyString())).thenReturn(true);


### PR DESCRIPTION


### JIRA link (if applicable) ###



### Change description ###
Upgrade the Netty Jar to fix CVE-2021-21409


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
