### PR TITLE
fix: Upgraded apache commons io version to latest to fix CVE-2021-29425

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -394,6 +394,8 @@ dependencies {
   implementation('io.netty:netty-handler-proxy:4.1.63.Final') {
     because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
   }
+  //Fix for CVE-2021-29425
+  implementation 'commons-io:commons-io:2.8.0'
   compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
 


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/RDCC-2743


### Change description ###
Upgraded apache commons io version to latest to fix CVE-2021-29425


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
