### PR TITLE
RDCC-2106  changed all Compile and testCompile entries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -302,55 +302,55 @@ repositories {
 
 dependencies {
 
-  compile group: 'org.apache.poi', name: 'poi', version: '4.1.2'
-  compile group: 'org.apache.poi', name: 'poi-ooxml', version: '4.1.2'
-  compile group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
-  compile group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: versions.springBoot
-  compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: versions.springBoot
-  compile group: 'org.springframework.boot', name: 'spring-boot-starter-json', version: versions.springBoot
-  compile group: 'org.springframework.boot', name: 'spring-boot-starter-security', version: versions.springBoot
-  compile group: 'org.springframework.boot', name: 'spring-boot-starter-jdbc'
-  compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: versions.springBoot
-  compile group: 'org.springframework.boot', name: 'spring-boot-starter-cache', version: versions.springBoot
+  implementation group: 'org.apache.poi', name: 'poi', version: '4.1.2'
+  implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '4.1.2'
+  implementation group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
+  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: versions.springBoot
+  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: versions.springBoot
+  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-json', version: versions.springBoot
+  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security', version: versions.springBoot
+  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-jdbc'
+  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: versions.springBoot
+  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-cache', version: versions.springBoot
 
 
-  compile group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '2.8.5'
-  compile group: 'io.github.openfeign.form', name: 'feign-form', version: '3.8.0'
-  compile group: 'io.github.openfeign.form', name: 'feign-form-spring', version: '3.8.0'
-  compile (group: 'io.rest-assured', name: 'rest-assured', version: '3.3.0') {
+  implementation group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '2.8.5'
+  implementation group: 'io.github.openfeign.form', name: 'feign-form', version: '3.8.0'
+  implementation group: 'io.github.openfeign.form', name: 'feign-form-spring', version: '3.8.0'
+  implementation (group: 'io.rest-assured', name: 'rest-assured', version: '3.3.0') {
     exclude group: "com.sun.xml.bind", module: "jaxb-osgi"
     exclude group: "org.apache.sling"
   }
-  compile group: 'com.sun.xml.bind', name: 'jaxb-osgi', version: '2.3.3'
-  compile group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
-  compile group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
+  implementation group: 'com.sun.xml.bind', name: 'jaxb-osgi', version: '2.3.3'
+  implementation group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
+  implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
 
-  compile group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformLogging
-  compile group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging
-  compile group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.1.0'
-  compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: versions.reformS2sClient
+  implementation group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformLogging
+  implementation group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging
+  implementation group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.1.0'
+  implementation group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: versions.reformS2sClient
 
-  compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: versions.jackson
-  compile group: 'io.jsonwebtoken', name: 'jjwt', version:'0.9.1'
-  compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: versions.jackson
-  compile group: 'javax.inject', name: 'javax.inject', version: '1'
-  compile group: 'uk.gov.hmcts.reform', name: 'idam-client', version: '1.5.5'
-  compile "org.springframework.boot:spring-boot-starter-oauth2-client"
-  compile "org.springframework.boot:spring-boot-starter-oauth2-resource-server"
-  compile group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '8.20'
+  implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: versions.jackson
+  implementation group: 'io.jsonwebtoken', name: 'jjwt', version:'0.9.1'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: versions.jackson
+  implementation group: 'javax.inject', name: 'javax.inject', version: '1'
+  implementation group: 'uk.gov.hmcts.reform', name: 'idam-client', version: '1.5.5'
+  implementation "org.springframework.boot:spring-boot-starter-oauth2-client"
+  implementation "org.springframework.boot:spring-boot-starter-oauth2-resource-server"
+  implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '8.20'
   implementation "io.github.openfeign:feign-httpclient:11.0"
   implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-  compile group: 'org.flywaydb', name: 'flyway-core', version: '5.2.4'
-  compile group: 'org.postgresql', name: 'postgresql', version: '42.2.14'
+  implementation group: 'org.flywaydb', name: 'flyway-core', version: '5.2.4'
+  implementation group: 'org.postgresql', name: 'postgresql', version: '42.2.14'
 
-  compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.13.3'
-  compile group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.13.3'
+  implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.13.3'
+  implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.13.3'
 
-  compile group: 'com.google.guava', name: 'guava', version: '30.1-jre'
-  compile group: 'javax.el', name: 'javax.el-api', version: '3.0.0'
-  compile group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: versions.launchDarklySdk
-  compile group:"org.yaml", name: "snakeyaml", version:"1.27"
+  implementation group: 'com.google.guava', name: 'guava', version: '30.1-jre'
+  implementation group: 'javax.el', name: 'javax.el-api', version: '3.0.0'
+  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: versions.launchDarklySdk
+  implementation group:"org.yaml", name: "snakeyaml", version:"1.27"
 
   implementation group: 'com.azure', name: 'azure-core', version: '1.13.0'
   implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.0.2'
@@ -408,47 +408,47 @@ dependencies {
     smokeTestCompileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     smokeTestAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
 
-  testCompile("org.hamcrest:hamcrest-junit:2.0.0.0") {
+  testImplementation("org.hamcrest:hamcrest-junit:2.0.0.0") {
     exclude group: "org.hamcrest", module: "hamcrest-core"
     exclude group: "org.hamcrest", module: "hamcrest-library"
   }
 
-    testCompile group: 'io.rest-assured', name: 'rest-assured', version: versions.restAssured
-    testCompile group: 'io.rest-assured', name: 'rest-assured-common', version: versions.restAssured
+    testImplementation group: 'io.rest-assured', name: 'rest-assured', version: versions.restAssured
+    testImplementation group: 'io.rest-assured', name: 'rest-assured-common', version: versions.restAssured
 
-    testCompile group: 'com.h2database', name: 'h2'
-    testCompile "com.github.tomakehurst:wiremock:2.21.0"
-    testCompile group: 'org.mockito', name: 'mockito-core', version: '3.4.6'
-    testCompile group: 'org.mockito', name: 'mockito-inline', version: '3.4.6'
-    testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.9'
+    testImplementation group: 'com.h2database', name: 'h2'
+    testImplementation "com.github.tomakehurst:wiremock:2.21.0"
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.4.6'
+    testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.4.6'
+    testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.9'
 
-    testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
+    testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
 
   contractTestCompile("org.junit.jupiter:junit-jupiter-api:5.6.2")
   contractTestRuntime("org.junit.jupiter:junit-jupiter-engine:5.6.2")
   contractTestImplementation('org.junit.jupiter:junit-jupiter-api:5.3.2')
 
-  testCompile group: 'org.pitest', name: 'pitest', version: versions.pitest
-  testCompile 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.4.6'
-  testCompile 'org.codehaus.sonar-plugins:sonar-pitest-plugin:0.5'
+  testImplementation group: 'org.pitest', name: 'pitest', version: versions.pitest
+  testImplementation 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.4.6'
+  testImplementation 'org.codehaus.sonar-plugins:sonar-pitest-plugin:0.5'
 
-  testCompile group: 'net.serenity-bdd', name: 'serenity-core', version: versions.serenity
-  testCompile group: 'net.serenity-bdd', name: 'serenity-junit', version: versions.serenity
-  testCompile group: 'net.serenity-bdd', name: 'serenity-rest-assured', version: versions.serenity
-  testCompile group: 'net.serenity-bdd', name: 'serenity-spring', version: versions.serenity
-  testCompile 'io.github.openfeign:feign-jackson:10.7.0'
-  testCompile group: 'com.github.mifmif', name: 'generex', version: '1.0.2'
+  testImplementation group: 'net.serenity-bdd', name: 'serenity-core', version: versions.serenity
+  testImplementation group: 'net.serenity-bdd', name: 'serenity-junit', version: versions.serenity
+  testImplementation group: 'net.serenity-bdd', name: 'serenity-rest-assured', version: versions.serenity
+  testImplementation group: 'net.serenity-bdd', name: 'serenity-spring', version: versions.serenity
+  testImplementation 'io.github.openfeign:feign-jackson:10.7.0'
+  testImplementation group: 'com.github.mifmif', name: 'generex', version: '1.0.2'
 
-  testCompile 'org.springframework.cloud:spring-cloud-contract-wiremock:2.2.4.RELEASE'
+  testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock:2.2.4.RELEASE'
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.2.14'
-  testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
-  testCompile('com.opentable.components:otj-pg-embedded:0.13.3')
-  testCompile group: 'org.codehaus.groovy', name: 'groovy', version: '2.5.14'
-  testCompile group: 'org.codehaus.groovy', name: 'groovy-xml', version: '2.5.14'
-  testCompile group: 'org.codehaus.groovy', name: 'groovy-json', version: '2.5.14'
-  testCompile group: 'org.springframework', name: 'spring-test', version: '5.2.9.RELEASE'
+  testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
+  testImplementation('com.opentable.components:otj-pg-embedded:0.13.3')
+  testImplementation group: 'org.codehaus.groovy', name: 'groovy', version: '2.5.14'
+  testImplementation group: 'org.codehaus.groovy', name: 'groovy-xml', version: '2.5.14'
+  testImplementation group: 'org.codehaus.groovy', name: 'groovy-json', version: '2.5.14'
+  testImplementation group: 'org.springframework', name: 'spring-test', version: '5.2.9.RELEASE'
 
-  compile group: 'org.apache.poi', name: 'poi-ooxml', version: '4.1.2'
+  implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '4.1.2'
 
   integrationTestCompile sourceSets.main.runtimeClasspath
   integrationTestCompile sourceSets.test.runtimeClasspath

--- a/build.gradle
+++ b/build.gradle
@@ -134,13 +134,13 @@ idea {
 }
 
 configurations {
-  integrationTestCompile.extendsFrom testCompile
+  integrationTestImplementation.extendsFrom testCompile
   integrationTestRuntime.extendsFrom testRuntime
-  functionalTestCompile.extendsFrom testCompile
+  functionalTestImplementation.extendsFrom testCompile
   functionalTestRuntime.extendsFrom testRuntime
-  contractTestCompile.extendsFrom testCompile
-  contractTestRuntime.extendsFrom testRuntime
-  pactTestCompile.extendsFrom testCompile
+  contractTestImplementation.extendsFrom testCompile
+  contractTestRuntimeOnly.extendsFrom testRuntime
+  pactTestImplementation.extendsFrom testCompile
   pactTestRuntime.extendsFrom testRuntime
 }
 
@@ -424,8 +424,8 @@ dependencies {
 
     testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
 
-  contractTestCompile("org.junit.jupiter:junit-jupiter-api:5.6.2")
-  contractTestRuntime("org.junit.jupiter:junit-jupiter-engine:5.6.2")
+  contractTestImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")
+  contractTestRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.6.2")
   contractTestImplementation('org.junit.jupiter:junit-jupiter-api:5.3.2')
 
   testImplementation group: 'org.pitest', name: 'pitest', version: versions.pitest
@@ -450,30 +450,30 @@ dependencies {
 
   implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '4.1.2'
 
-  integrationTestCompile sourceSets.main.runtimeClasspath
-  integrationTestCompile sourceSets.test.runtimeClasspath
+  integrationTestImplementation sourceSets.main.runtimeClasspath
+  integrationTestImplementation sourceSets.test.runtimeClasspath
 
-  functionalTestCompile sourceSets.main.runtimeClasspath
-  functionalTestCompile sourceSets.test.runtimeClasspath
+  functionalTestImplementation sourceSets.main.runtimeClasspath
+  functionalTestImplementation sourceSets.test.runtimeClasspath
 
-  smokeTestCompile sourceSets.main.runtimeClasspath
-  smokeTestCompile sourceSets.test.runtimeClasspath
+  smokeTestImplementation sourceSets.main.runtimeClasspath
+  smokeTestImplementation sourceSets.test.runtimeClasspath
 
-  contractTestCompile group: 'au.com.dius.pact.consumer', name: 'junit5', version: '4.1.7'
-  contractTestCompile group: 'au.com.dius.pact.consumer', name: 'java8', version: '4.1.7'
-  contractTestRuntime group: 'au.com.dius.pact.consumer', name: 'junit5', version: '4.1.7'
-  contractTestRuntime group: 'au.com.dius.pact.consumer', name: 'java8', version: '4.1.7'
-  contractTestCompile group: 'au.com.dius.pact.provider', name: 'junit5', version: '4.1.7'
-  contractTestCompile group: 'au.com.dius.pact.provider', name: 'spring', version: '4.1.7'
-  contractTestCompile group: 'au.com.dius.pact.provider', name: 'junit5spring', version: '4.1.7'
+  contractTestImplementation group: 'au.com.dius.pact.consumer', name: 'junit5', version: '4.1.7'
+  contractTestImplementation group: 'au.com.dius.pact.consumer', name: 'java8', version: '4.1.7'
+  contractTestRuntimeOnly group: 'au.com.dius.pact.consumer', name: 'junit5', version: '4.1.7'
+  contractTestRuntimeOnly group: 'au.com.dius.pact.consumer', name: 'java8', version: '4.1.7'
+  contractTestImplementation group: 'au.com.dius.pact.provider', name: 'junit5', version: '4.1.7'
+  contractTestImplementation group: 'au.com.dius.pact.provider', name: 'spring', version: '4.1.7'
+  contractTestImplementation group: 'au.com.dius.pact.provider', name: 'junit5spring', version: '4.1.7'
 
-  contractTestCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
+  contractTestImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
 
-  contractTestCompile sourceSets.main.runtimeClasspath
-  contractTestCompile sourceSets.test.runtimeClasspath
+  contractTestImplementation sourceSets.main.runtimeClasspath
+  contractTestImplementation sourceSets.test.runtimeClasspath
 
-  pactTestCompile sourceSets.main.runtimeClasspath
-  pactTestCompile sourceSets.test.runtimeClasspath
+  pactTestImplementation sourceSets.main.runtimeClasspath
+  pactTestImplementation sourceSets.test.runtimeClasspath
 }
 
 dependencyCheck {
@@ -496,7 +496,7 @@ dependencyUpdates.resolutionStrategy = {
 gradle.startParameter.continueOnFailure = true
 
 bootJar {
-  archiveName = jarName
+  archiveFileName = jarName
   manifest {
     attributes('Implementation-Version': project.version.toString())
   }


### PR DESCRIPTION


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-2106

### Change description ###
Since Compile and testCompile entries are deprecated from gradle 7 hence changed all the Compile and testCompile entries in the build.gradle file to Implementation and testImplementation.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
