### PR TITLE
fix: RDCC-2925 Handled invalid request

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/cwrdapi/CaseWorkerRefFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/cwrdapi/CaseWorkerRefFunctionalTest.java
@@ -386,7 +386,7 @@ public class CaseWorkerRefFunctionalTest extends AuthorizationFunctionalTest {
 
     @Test
     @ToggleEnable(mapKey = FETCH_STAFF_BY_CCD_SERVICE_NAMES, withFeature = true)
-    public void shouldFetchStaffProfileByCcdServiceNames() {
+    public void shouldFetchStaffProfileByCcdServiceNamesWithDefaultParams() {
         if (isEmpty(caseWorkerIds)) {
             createCaseWorkerIds();
         }
@@ -408,6 +408,34 @@ public class CaseWorkerRefFunctionalTest extends AuthorizationFunctionalTest {
                 .forEach(p -> actualServiceNames.add(p.getCcdServiceName().toLowerCase()));
 
         assertTrue(actualServiceNames.containsAll(expectedServiceNames));
+    }
+
+    @Test
+    @ToggleEnable(mapKey = FETCH_STAFF_BY_CCD_SERVICE_NAMES, withFeature = true)
+    public void shouldFetchStaffProfileByCcdServiceNamesWithPaginatedParams() {
+        if (isEmpty(caseWorkerIds)) {
+            createCaseWorkerIds();
+        }
+        Set<String> expectedServiceNames = Set.of("cmc", "divorce");
+        String ccdServiceNames = String.join(",", expectedServiceNames);
+        Response fetchResponse = caseWorkerApiClient.getMultipleAuthHeadersWithoutContentType(ROLE_CWD_SYSTEM_USER)
+                .get(STAFF_BY_SERVICE_NAME_URL
+                        + "?ccd_service_names=" + ccdServiceNames
+                        + "&page_number=0&page_size=2&sort_column=caseWorkerId&sort_direction=ASC")
+                .andReturn();
+        fetchResponse.then()
+                .assertThat()
+                .statusCode(200);
+        List<StaffProfileWithServiceName> paginatedStaffProfile =
+                Arrays.asList(fetchResponse.getBody().as(StaffProfileWithServiceName[].class));
+
+        assertFalse(paginatedStaffProfile.isEmpty());
+        Set<String> actualServiceNames = new HashSet<>();
+        paginatedStaffProfile
+                .forEach(p -> actualServiceNames.add(p.getCcdServiceName().toLowerCase()));
+
+        assertTrue(actualServiceNames.containsAll(expectedServiceNames));
+        assertEquals(2, paginatedStaffProfile.size());
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/reform/cwrdapi/controllers/advice/ExceptionMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/cwrdapi/controllers/advice/ExceptionMapper.java
@@ -91,7 +91,10 @@ public class ExceptionMapper {
 
     @ExceptionHandler(StaffReferenceException.class)
     public ResponseEntity<Object> handleJsonFeignResponseException(StaffReferenceException ex) {
-        return errorDetailsResponseEntity(ex, ex.getStatus(), ex.getMessage());
+        ErrorResponse errorDetails = new ErrorResponse(ex.getStatus().value(),ex.getStatus().getReasonPhrase(),
+                ex.getErrorMessage(), ex.getErrorDescription(), getTimeStamp());
+
+        return new ResponseEntity<>(errorDetails, ex.getStatus());
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/uk/gov/hmcts/reform/cwrdapi/controllers/advice/StaffReferenceException.java
+++ b/src/main/java/uk/gov/hmcts/reform/cwrdapi/controllers/advice/StaffReferenceException.java
@@ -8,14 +8,14 @@ public class StaffReferenceException extends RuntimeException {
 
     private final HttpStatus status;
     private final String errorMessage;
-    private final Throwable exception;
+    private final String errorDescription;
 
     public StaffReferenceException(HttpStatus status,
                                    String errorMessage,
-                                   Throwable exception) {
-        super(errorMessage, exception);
+                                   String errorDescription) {
+        super(errorMessage);
         this.status = status;
         this.errorMessage = errorMessage;
-        this.exception = exception;
+        this.errorDescription = errorDescription;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/cwrdapi/controllers/internal/StaffReferenceInternalController.java
+++ b/src/main/java/uk/gov/hmcts/reform/cwrdapi/controllers/internal/StaffReferenceInternalController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.cwrdapi.client.domain.StaffProfileWithServiceName;
 import uk.gov.hmcts.reform.cwrdapi.controllers.advice.InvalidRequestException;
+import uk.gov.hmcts.reform.cwrdapi.domain.CaseWorkerProfile;
 import uk.gov.hmcts.reform.cwrdapi.service.CaseWorkerService;
 import uk.gov.hmcts.reform.cwrdapi.util.RequestUtils;
 
@@ -106,8 +107,12 @@ public class StaffReferenceInternalController {
         if (StringUtils.isBlank(ccdServiceNames)) {
             throw new InvalidRequestException(REQUIRED_PARAMETER_CCD_SERVICE_NAMES_IS_EMPTY);
         }
+
         PageRequest pageRequest = RequestUtils.validateAndBuildPaginationObject(pageNumber, pageSize,
-                sortColumn, sortDirection, loggingComponentName, configPageSize, configSortColumn);
+                sortColumn, sortDirection, loggingComponentName, configPageSize, configSortColumn,
+                CaseWorkerProfile.class);
+
+
         return caseWorkerService.fetchStaffProfilesForRoleRefresh(ccdServiceNames, pageRequest);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/cwrdapi/controllers/internal/StaffReferenceInternalController.java
+++ b/src/main/java/uk/gov/hmcts/reform/cwrdapi/controllers/internal/StaffReferenceInternalController.java
@@ -109,8 +109,7 @@ public class StaffReferenceInternalController {
         }
 
         PageRequest pageRequest = RequestUtils.validateAndBuildPaginationObject(pageNumber, pageSize,
-                sortColumn, sortDirection, loggingComponentName, configPageSize, configSortColumn,
-                CaseWorkerProfile.class);
+                sortColumn, sortDirection, configPageSize, configSortColumn, CaseWorkerProfile.class);
 
 
         return caseWorkerService.fetchStaffProfilesForRoleRefresh(ccdServiceNames, pageRequest);

--- a/src/main/java/uk/gov/hmcts/reform/cwrdapi/util/CaseWorkerConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/cwrdapi/util/CaseWorkerConstants.java
@@ -141,10 +141,13 @@ public final class CaseWorkerConstants {
     public static final String PAGE_NUMBER = "Page Number";
     public static final String PAGE_SIZE = "Page Size";
     public static final String SORT_DIRECTION = "Sort Direction";
+    public static final String SORT_COLUMN = "Sort Column";
     public static final String API_IS_NOT_AVAILABLE_IN_PROD_ENV = "This API is not available in Production Environment";
     public static final String REQUIRED_PARAMETER_CCD_SERVICE_NAMES_IS_EMPTY =
             "The required parameter 'ccd_service_names' is empty";
 
     public static final String ERROR_IN_PARSING_THE_FEIGN_RESPONSE = "Error in parsing %s Feign Response";
+
+    public static final String LRD_ERROR = "An error occurred while retrieving data from Location Reference Data";
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/cwrdapi/util/JsonFeignResponseUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/cwrdapi/util/JsonFeignResponseUtil.java
@@ -44,7 +44,8 @@ public class JsonFeignResponseUtil {
             return json.readValue(response.body().asReader(Charset.defaultCharset()), type);
         } catch (Exception e) {
             throw new StaffReferenceException(INTERNAL_SERVER_ERROR,
-                    String.format(ERROR_IN_PARSING_THE_FEIGN_RESPONSE, ((Class<?>) clazz).getSimpleName()), e);
+                    String.format(ERROR_IN_PARSING_THE_FEIGN_RESPONSE, ((Class<?>) clazz).getSimpleName()),
+                    e.getLocalizedMessage());
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/cwrdapi/util/RequestUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/cwrdapi/util/RequestUtils.java
@@ -50,30 +50,25 @@ public class RequestUtils {
                                                                Integer pageSize,
                                                                String sortColumn,
                                                                String sortDirection,
-                                                               String loggingComponentName,
                                                                int configPageSize,
                                                                String configSortColumn,
                                                                Class<?> entityClass) {
 
         if (Objects.nonNull(pageNumber) && pageNumber < 0) {
-            log.info("{}:: Invalid Page Number {}", loggingComponentName, pageNumber);
             throw new InvalidRequestException(String.format(INVALID_FIELD, PAGE_NUMBER));
         }
         if (Objects.nonNull(pageSize) && pageSize <= 0) {
-            log.info("{}:: Invalid Page Size {}", loggingComponentName, pageSize);
             throw new InvalidRequestException(String.format(INVALID_FIELD, PAGE_SIZE));
         }
         if (!StringUtils.isEmpty(sortDirection)) {
             try {
                 Sort.Direction.fromString(sortDirection);
             } catch (IllegalArgumentException illegalArgumentException) {
-                log.info("{}:: Invalid Sort Direction {}", loggingComponentName, sortDirection);
                 throw new InvalidRequestException(String.format(INVALID_FIELD, SORT_DIRECTION));
             }
         }
         String finalSortColumn = StringUtils.isBlank(sortColumn) ? configSortColumn : sortColumn;
         if (!isValidSortColumn(finalSortColumn, entityClass)) {
-            log.info("{}:: Invalid Sort Column {}", loggingComponentName, finalSortColumn);
             throw new InvalidRequestException(String.format(INVALID_FIELD, SORT_COLUMN));
         }
         return PageRequest.of(Objects.isNull(pageNumber) ? 0 : pageNumber,
@@ -87,5 +82,4 @@ public class RequestUtils {
         Field field = ReflectionUtils.findField(entityClass, finalSortColumn);
         return Objects.nonNull(field);
     }
-
 }

--- a/src/main/java/uk/gov/hmcts/reform/cwrdapi/util/RequestUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/cwrdapi/util/RequestUtils.java
@@ -5,9 +5,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.util.ReflectionUtils;
 import uk.gov.hmcts.reform.cwrdapi.controllers.advice.InvalidRequestException;
 import uk.gov.hmcts.reform.cwrdapi.controllers.request.CaseWorkersProfileCreationRequest;
 
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -17,6 +19,7 @@ import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 import static uk.gov.hmcts.reform.cwrdapi.util.CaseWorkerConstants.INVALID_FIELD;
 import static uk.gov.hmcts.reform.cwrdapi.util.CaseWorkerConstants.PAGE_NUMBER;
 import static uk.gov.hmcts.reform.cwrdapi.util.CaseWorkerConstants.PAGE_SIZE;
+import static uk.gov.hmcts.reform.cwrdapi.util.CaseWorkerConstants.SORT_COLUMN;
 import static uk.gov.hmcts.reform.cwrdapi.util.CaseWorkerConstants.SORT_DIRECTION;
 
 @Slf4j
@@ -49,28 +52,40 @@ public class RequestUtils {
                                                                String sortDirection,
                                                                String loggingComponentName,
                                                                int configPageSize,
-                                                               String configSortColumn) {
+                                                               String configSortColumn,
+                                                               Class<?> entityClass) {
 
         if (Objects.nonNull(pageNumber) && pageNumber < 0) {
-            log.info("{}:: Invalid Page Number", loggingComponentName);
+            log.info("{}:: Invalid Page Number {}", loggingComponentName, pageNumber);
             throw new InvalidRequestException(String.format(INVALID_FIELD, PAGE_NUMBER));
         }
         if (Objects.nonNull(pageSize) && pageSize <= 0) {
-            log.info("{}:: Invalid Page Size", loggingComponentName);
+            log.info("{}:: Invalid Page Size {}", loggingComponentName, pageSize);
             throw new InvalidRequestException(String.format(INVALID_FIELD, PAGE_SIZE));
         }
         if (!StringUtils.isEmpty(sortDirection)) {
             try {
                 Sort.Direction.fromString(sortDirection);
             } catch (IllegalArgumentException illegalArgumentException) {
-                log.info("{}:: Invalid Sort Direction", loggingComponentName);
+                log.info("{}:: Invalid Sort Direction {}", loggingComponentName, sortDirection);
                 throw new InvalidRequestException(String.format(INVALID_FIELD, SORT_DIRECTION));
             }
+        }
+        String finalSortColumn = StringUtils.isBlank(sortColumn) ? configSortColumn : sortColumn;
+        if (!isValidSortColumn(finalSortColumn, entityClass)) {
+            log.info("{}:: Invalid Sort Column {}", loggingComponentName, finalSortColumn);
+            throw new InvalidRequestException(String.format(INVALID_FIELD, SORT_COLUMN));
         }
         return PageRequest.of(Objects.isNull(pageNumber) ? 0 : pageNumber,
                 Objects.isNull(pageSize) ? configPageSize : pageSize,
                 StringUtils.isBlank(sortDirection) ? Sort.Direction.ASC : Sort.Direction.fromString(sortDirection),
-                StringUtils.isBlank(sortColumn) ? configSortColumn : sortColumn);
+                finalSortColumn);
+    }
+
+    private static boolean isValidSortColumn(String finalSortColumn,
+                                             Class<?> entityClass) {
+        Field field = ReflectionUtils.findField(entityClass, finalSortColumn);
+        return Objects.nonNull(field);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/cwrdapi/controllers/advice/ExceptionMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/cwrdapi/controllers/advice/ExceptionMapperTest.java
@@ -118,12 +118,13 @@ public class ExceptionMapperTest {
     @Test
     public void test_handle_json_feign_response_parsing_exception() {
         StaffReferenceException exception = new StaffReferenceException(HttpStatus.INTERNAL_SERVER_ERROR,
-                "Parsing exception", new RuntimeException("Parsing exception"));
+                "Parsing exception", "Parsing exception");
 
         ResponseEntity<Object> responseEntity = exceptionMapper.handleJsonFeignResponseException(exception);
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, responseEntity.getStatusCode());
-        assertEquals(exception.getMessage(), ((ErrorResponse)responseEntity.getBody()).getErrorDescription());
+        assertEquals(exception.getErrorMessage(), ((ErrorResponse)responseEntity.getBody()).getErrorDescription());
+        assertEquals(exception.getErrorDescription(), ((ErrorResponse)responseEntity.getBody()).getErrorDescription());
 
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/cwrdapi/controllers/advice/StaffReferenceExceptionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/cwrdapi/controllers/advice/StaffReferenceExceptionTest.java
@@ -11,9 +11,10 @@ public class StaffReferenceExceptionTest {
     public void test_handle_json_feign_response_parsing_exception() {
         StaffReferenceException staffReferenceException =
                 new StaffReferenceException(HttpStatus.INTERNAL_SERVER_ERROR,
-                        "Parsing exception", new RuntimeException());
+                        "Parsing exception", "Parsing exception");
         assertThat(staffReferenceException).isNotNull();
-        assertEquals("Parsing exception", staffReferenceException.getMessage());
+        assertEquals("Parsing exception", staffReferenceException.getErrorMessage());
+        assertEquals("Parsing exception", staffReferenceException.getErrorDescription());
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, staffReferenceException.getStatus());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/cwrdapi/controllers/internal/StaffReferenceInternalControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/cwrdapi/controllers/internal/StaffReferenceInternalControllerTest.java
@@ -33,7 +33,7 @@ public class StaffReferenceInternalControllerTest {
                 .thenReturn(responseEntity);
 
         PageRequest pageRequest = RequestUtils.validateAndBuildPaginationObject(0, 1,
-                "caseWorkerId", "ASC", "test",
+                "caseWorkerId", "ASC",
                 20, "id", CaseWorkerProfile.class);
 
         ResponseEntity<?> actual = staffReferenceInternalController

--- a/src/test/java/uk/gov/hmcts/reform/cwrdapi/controllers/internal/StaffReferenceInternalControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/cwrdapi/controllers/internal/StaffReferenceInternalControllerTest.java
@@ -8,6 +8,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.reform.cwrdapi.controllers.advice.InvalidRequestException;
+import uk.gov.hmcts.reform.cwrdapi.domain.CaseWorkerProfile;
 import uk.gov.hmcts.reform.cwrdapi.service.CaseWorkerService;
 import uk.gov.hmcts.reform.cwrdapi.util.RequestUtils;
 
@@ -33,7 +34,7 @@ public class StaffReferenceInternalControllerTest {
 
         PageRequest pageRequest = RequestUtils.validateAndBuildPaginationObject(0, 1,
                 "caseWorkerId", "ASC", "test",
-                20, "id");
+                20, "id", CaseWorkerProfile.class);
 
         ResponseEntity<?> actual = staffReferenceInternalController
                 .fetchStaffByCcdServiceNames("cmc", 1, 0,

--- a/src/test/java/uk/gov/hmcts/reform/cwrdapi/service/impl/CaseWorkerServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/cwrdapi/service/impl/CaseWorkerServiceImplTest.java
@@ -962,7 +962,7 @@ public class CaseWorkerServiceImplTest {
         CaseWorkerProfile caseWorkerProfile = buildCaseWorkerProfile();
 
         PageRequest pageRequest = RequestUtils.validateAndBuildPaginationObject(0, 1,
-                "caseWorkerId", "ASC", "test",
+                "caseWorkerId", "ASC",
                 20, "id", CaseWorkerProfile.class);
 
         PageImpl<CaseWorkerProfile> page = new PageImpl<>(Collections.singletonList(caseWorkerProfile));
@@ -979,7 +979,7 @@ public class CaseWorkerServiceImplTest {
     public void testRefreshRoleAllocationWhenLrdResponseIsNon200() {
 
         PageRequest pageRequest = RequestUtils.validateAndBuildPaginationObject(0, 1,
-                "caseWorkerId", "ASC", "test",
+                "caseWorkerId", "ASC",
                 20, "id", CaseWorkerProfile.class);
         when(locationReferenceDataFeignClient.getLocationRefServiceMapping("cmc"))
                 .thenReturn(Response.builder()
@@ -1004,7 +1004,7 @@ public class CaseWorkerServiceImplTest {
                         .request(mock(Request.class)).body(body, defaultCharset()).status(201).build());
 
         PageRequest pageRequest = RequestUtils.validateAndBuildPaginationObject(0, 1,
-                "caseWorkerId", "ASC", "test",
+                "caseWorkerId", "ASC",
                 20, "id", CaseWorkerProfile.class);
 
         PageImpl<CaseWorkerProfile> page = new PageImpl<>(Collections.emptyList());
@@ -1027,7 +1027,7 @@ public class CaseWorkerServiceImplTest {
         List<CaseWorkerWorkArea> caseWorkerWorkAreas = new ArrayList<>();
 
         PageRequest pageRequest = RequestUtils.validateAndBuildPaginationObject(0, 1,
-                "caseWorkerId", "ASC", "test",
+                "caseWorkerId", "ASC",
                 20, "id", CaseWorkerProfile.class);
 
         caseWorkerServiceImpl
@@ -1051,7 +1051,7 @@ public class CaseWorkerServiceImplTest {
 
 
         PageRequest pageRequest = RequestUtils.validateAndBuildPaginationObject(0, 1,
-                "caseWorkerId", "ASC", "test",
+                "caseWorkerId", "ASC",
                 20, "id", CaseWorkerProfile.class);
 
         caseWorkerServiceImpl

--- a/src/test/java/uk/gov/hmcts/reform/cwrdapi/service/impl/CaseWorkerServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/cwrdapi/service/impl/CaseWorkerServiceImplTest.java
@@ -25,6 +25,7 @@ import uk.gov.hmcts.reform.cwrdapi.client.domain.UserProfileRolesResponse;
 import uk.gov.hmcts.reform.cwrdapi.client.domain.WorkArea;
 import uk.gov.hmcts.reform.cwrdapi.controllers.advice.IdamRolesMappingException;
 import uk.gov.hmcts.reform.cwrdapi.controllers.advice.ResourceNotFoundException;
+import uk.gov.hmcts.reform.cwrdapi.controllers.advice.StaffReferenceException;
 import uk.gov.hmcts.reform.cwrdapi.controllers.feign.LocationReferenceDataFeignClient;
 import uk.gov.hmcts.reform.cwrdapi.controllers.feign.UserProfileFeignClient;
 import uk.gov.hmcts.reform.cwrdapi.controllers.request.CaseWorkerLocationRequest;
@@ -961,7 +962,7 @@ public class CaseWorkerServiceImplTest {
 
         PageRequest pageRequest = RequestUtils.validateAndBuildPaginationObject(0, 1,
                 "caseWorkerId", "ASC", "test",
-                20, "id");
+                20, "id", CaseWorkerProfile.class);
 
         PageImpl<CaseWorkerProfile> page = new PageImpl<>(Collections.singletonList(caseWorkerProfile));
         when(caseWorkerProfileRepository.findByServiceCodeIn(Set.of("BAA1"), pageRequest))
@@ -973,12 +974,12 @@ public class CaseWorkerServiceImplTest {
 
     }
 
-    @Test(expected = ResourceNotFoundException.class)
+    @Test(expected = StaffReferenceException.class)
     public void testRefreshRoleAllocationWhenLrdResponseIsNon200() {
 
         PageRequest pageRequest = RequestUtils.validateAndBuildPaginationObject(0, 1,
                 "caseWorkerId", "ASC", "test",
-                20, "id");
+                20, "id", CaseWorkerProfile.class);
         when(locationReferenceDataFeignClient.getLocationRefServiceMapping("cmc"))
                 .thenReturn(Response.builder()
                         .request(mock(Request.class)).body("body", defaultCharset()).status(400).build());
@@ -1003,7 +1004,7 @@ public class CaseWorkerServiceImplTest {
 
         PageRequest pageRequest = RequestUtils.validateAndBuildPaginationObject(0, 1,
                 "caseWorkerId", "ASC", "test",
-                20, "id");
+                20, "id", CaseWorkerProfile.class);
 
         PageImpl<CaseWorkerProfile> page = new PageImpl<>(Collections.emptyList());
         when(caseWorkerProfileRepository.findByServiceCodeIn(Set.of("BAA1"), pageRequest))
@@ -1012,7 +1013,7 @@ public class CaseWorkerServiceImplTest {
                 .fetchStaffProfilesForRoleRefresh("cmc", pageRequest);
     }
 
-    @Test(expected = ResourceNotFoundException.class)
+    @Test(expected = StaffReferenceException.class)
     public void testRefreshRoleAllocationWhenLrdResponseIsEmpty() throws JsonProcessingException {
 
         String body = mapper.writeValueAsString(Collections.emptyList());
@@ -1026,7 +1027,7 @@ public class CaseWorkerServiceImplTest {
 
         PageRequest pageRequest = RequestUtils.validateAndBuildPaginationObject(0, 1,
                 "caseWorkerId", "ASC", "test",
-                20, "id");
+                20, "id", CaseWorkerProfile.class);
 
         caseWorkerServiceImpl
                 .fetchStaffProfilesForRoleRefresh("cmc", pageRequest);

--- a/src/test/java/uk/gov/hmcts/reform/cwrdapi/service/impl/CaseWorkerServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/cwrdapi/service/impl/CaseWorkerServiceImplTest.java
@@ -23,6 +23,7 @@ import uk.gov.hmcts.reform.cwrdapi.client.domain.ServiceRoleMapping;
 import uk.gov.hmcts.reform.cwrdapi.client.domain.UserProfileResponse;
 import uk.gov.hmcts.reform.cwrdapi.client.domain.UserProfileRolesResponse;
 import uk.gov.hmcts.reform.cwrdapi.client.domain.WorkArea;
+import uk.gov.hmcts.reform.cwrdapi.controllers.advice.ErrorResponse;
 import uk.gov.hmcts.reform.cwrdapi.controllers.advice.IdamRolesMappingException;
 import uk.gov.hmcts.reform.cwrdapi.controllers.advice.ResourceNotFoundException;
 import uk.gov.hmcts.reform.cwrdapi.controllers.advice.StaffReferenceException;
@@ -1024,6 +1025,30 @@ public class CaseWorkerServiceImplTest {
 
 
         List<CaseWorkerWorkArea> caseWorkerWorkAreas = new ArrayList<>();
+
+        PageRequest pageRequest = RequestUtils.validateAndBuildPaginationObject(0, 1,
+                "caseWorkerId", "ASC", "test",
+                20, "id", CaseWorkerProfile.class);
+
+        caseWorkerServiceImpl
+                .fetchStaffProfilesForRoleRefresh("cmc", pageRequest);
+    }
+
+    @Test(expected = StaffReferenceException.class)
+    public void testRefreshRoleAllocationWhenLrdResponseReturns400() throws JsonProcessingException {
+        ErrorResponse errorResponse = ErrorResponse
+                .builder()
+                .errorCode(400)
+                .errorDescription("testErrorDesc")
+                .errorMessage("testErrorMsg")
+                .build()
+                ;
+        String body = mapper.writeValueAsString(errorResponse);
+
+        when(locationReferenceDataFeignClient.getLocationRefServiceMapping("cmc"))
+                .thenReturn(Response.builder()
+                        .request(mock(Request.class)).body(body, defaultCharset()).status(400).build());
+
 
         PageRequest pageRequest = RequestUtils.validateAndBuildPaginationObject(0, 1,
                 "caseWorkerId", "ASC", "test",

--- a/src/test/java/uk/gov/hmcts/reform/cwrdapi/util/RequestUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/cwrdapi/util/RequestUtilsTest.java
@@ -33,7 +33,7 @@ public class RequestUtilsTest {
     public void testValidateAndBuildPaginationObject() {
         PageRequest pageRequest =
                 validateAndBuildPaginationObject(0, 1,
-                        "caseWorkerId", "ASC", "test",
+                        "caseWorkerId", "ASC",
                         20, "id", CaseWorkerProfile.class);
         assertEquals(0, pageRequest.first().getPageNumber());
         assertEquals(1, pageRequest.first().getPageSize());
@@ -42,21 +42,21 @@ public class RequestUtilsTest {
     @Test(expected = InvalidRequestException.class)
     public void testInvalidRequestExceptionForInvalidPageNumber() {
         validateAndBuildPaginationObject(-1, 1,
-                "caseWorkerId", "ASC", "test",
+                "caseWorkerId", "ASC",
                 20, "id", CaseWorkerProfile.class);
     }
 
     @Test(expected = InvalidRequestException.class)
     public void testInvalidRequestExceptionForInvalidPageSize() {
         validateAndBuildPaginationObject(0, -1,
-                "caseWorkerId", "ASC", "test",
+                "caseWorkerId", "ASC",
                 20, "id", CaseWorkerProfile.class);
     }
 
     @Test(expected = InvalidRequestException.class)
     public void testInvalidRequestExceptionForInvalidSortDirection() {
         validateAndBuildPaginationObject(0, 1,
-                "caseWorkerId", "Invalid", "test",
+                "caseWorkerId", "Invalid",
                 20, "id", CaseWorkerProfile.class);
     }
 
@@ -64,7 +64,7 @@ public class RequestUtilsTest {
     public void testConfigValueWhenPaginationParametersNotProvided() {
         PageRequest pageRequest =
                 validateAndBuildPaginationObject(null, null,
-                        null, null, "test",
+                        null, null,
                         20, "caseWorkerId", CaseWorkerProfile.class);
         assertEquals(0, pageRequest.getPageNumber());
         assertEquals(20, pageRequest.getPageSize());
@@ -75,7 +75,7 @@ public class RequestUtilsTest {
     @Test(expected = InvalidRequestException.class)
     public void testInvalidRequestExceptionForInvalidSortColumn() {
         validateAndBuildPaginationObject(0, 1,
-                "invalid", "ASC", "test",
+                "invalid", "ASC",
                 20, "invalid", CaseWorkerProfile.class);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/cwrdapi/util/RequestUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/cwrdapi/util/RequestUtilsTest.java
@@ -71,4 +71,11 @@ public class RequestUtilsTest {
         assertTrue(pageRequest.getSort().get().anyMatch(i -> i.getDirection().isAscending()));
         assertTrue(pageRequest.getSort().get().anyMatch(i -> i.getProperty().equals("caseWorkerId")));
     }
+
+    @Test(expected = InvalidRequestException.class)
+    public void testInvalidRequestExceptionForInvalidSortColumn() {
+        validateAndBuildPaginationObject(0, 1,
+                "invalid", "ASC", "test",
+                20, "invalid", CaseWorkerProfile.class);
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/cwrdapi/util/RequestUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/cwrdapi/util/RequestUtilsTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.springframework.data.domain.PageRequest;
 import uk.gov.hmcts.reform.cwrdapi.controllers.advice.InvalidRequestException;
 import uk.gov.hmcts.reform.cwrdapi.controllers.request.CaseWorkersProfileCreationRequest;
+import uk.gov.hmcts.reform.cwrdapi.domain.CaseWorkerProfile;
 
 import java.util.List;
 import java.util.Set;
@@ -33,7 +34,7 @@ public class RequestUtilsTest {
         PageRequest pageRequest =
                 validateAndBuildPaginationObject(0, 1,
                         "caseWorkerId", "ASC", "test",
-                        20, "id");
+                        20, "id", CaseWorkerProfile.class);
         assertEquals(0, pageRequest.first().getPageNumber());
         assertEquals(1, pageRequest.first().getPageSize());
     }
@@ -42,21 +43,21 @@ public class RequestUtilsTest {
     public void testInvalidRequestExceptionForInvalidPageNumber() {
         validateAndBuildPaginationObject(-1, 1,
                 "caseWorkerId", "ASC", "test",
-                20, "id");
+                20, "id", CaseWorkerProfile.class);
     }
 
     @Test(expected = InvalidRequestException.class)
     public void testInvalidRequestExceptionForInvalidPageSize() {
         validateAndBuildPaginationObject(0, -1,
                 "caseWorkerId", "ASC", "test",
-                20, "id");
+                20, "id", CaseWorkerProfile.class);
     }
 
     @Test(expected = InvalidRequestException.class)
     public void testInvalidRequestExceptionForInvalidSortDirection() {
         validateAndBuildPaginationObject(0, 1,
                 "caseWorkerId", "Invalid", "test",
-                20, "id");
+                20, "id", CaseWorkerProfile.class);
     }
 
     @Test
@@ -64,7 +65,7 @@ public class RequestUtilsTest {
         PageRequest pageRequest =
                 validateAndBuildPaginationObject(null, null,
                         null, null, "test",
-                        20, "caseWorkerId");
+                        20, "caseWorkerId", CaseWorkerProfile.class);
         assertEquals(0, pageRequest.getPageNumber());
         assertEquals(20, pageRequest.getPageSize());
         assertTrue(pageRequest.getSort().get().anyMatch(i -> i.getDirection().isAscending()));


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/RDCC-2925


### Change description ###

Handled following observations

- When we supply more than one column in sorting column we get 404 instead 400
- When we supply invalid service name ( * or special char )it shows 404 instead 400

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
