### PR TITLE
fix:RDCC-3167 Upgraded the commons-compress to address CVE-2021-35515 CVE-2021-35516, CVE-2021-35517, CVE-2021-36090

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -453,6 +453,8 @@ dependencies {
   testImplementation group: 'org.springframework', name: 'spring-test', version: '5.3.8'
 
   implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '4.1.2'
+  //Fix for CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090
+  implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.21'
 
   integrationTestImplementation sourceSets.main.runtimeClasspath
   integrationTestImplementation sourceSets.test.runtimeClasspath


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/RDCC-3167


### Change description ###

Upgraded the commons-compress to address CVE-2021-35515 CVE-2021-35516, CVE-2021-35517, CVE-2021-36090

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
