### PR TITLE
RDCC-3254 - added CVE-2020-23171 entry in suppressions.xml

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -14,4 +14,11 @@
     <packageUrl regex="true">^pkg:maven/org\.glassfish/jakarta\.el@.*$</packageUrl>
     <cve>CVE-2021-28170</cve>
   </suppress>
+  <suppress until="2021-09-25">
+    <notes>A vulnerability in all versions of Nim-lang allows unauthenticated attackers to write files to
+      arbitrary directories via a crafted zip file with dot-slash characters included in the name of the
+      crafted file
+    </notes>
+    <cve>CVE-2020-23171</cve>
+  </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -14,11 +14,11 @@
     <packageUrl regex="true">^pkg:maven/org\.glassfish/jakarta\.el@.*$</packageUrl>
     <cve>CVE-2021-28170</cve>
   </suppress>
-  <suppress until="2021-09-25">
-    <notes>A vulnerability in all versions of Nim-lang allows unauthenticated attackers to write files to
-      arbitrary directories via a crafted zip file with dot-slash characters included in the name of the
-      crafted file
-    </notes>
+  <suppress until="2021-11-16">
+    <notes><![CDATA[
+   file name: lang-tag-1.4.4.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.nimbusds/lang\-tag@.*$</packageUrl>
     <cve>CVE-2020-23171</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDCC-3254


### Change description ###
RDCC-3254 - added CVE-2020-23171 entry in suppressions.xml


**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes
[ ] No
```
