### PR TITLE
fix: CVE-2021-45105 by upgrading log4j to 2.17.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ def versions = [
   restAssured        : '4.3.3',
   jackson            : '2.12.1',
   log4j              : '2.16.0'
+  
 ]
 
 mainClassName = 'uk.gov.hmcts.reform.cwrdapi.CaseWorkerRefApiApplication'

--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,7 @@ def versions = [
   launchDarklySdk    : "5.2.2",
   restAssured        : '4.3.3',
   jackson            : '2.12.1',
-  log4j              : '2.16.0'
-  
+  log4j              : '2.17.0'
 ]
 
 mainClassName = 'uk.gov.hmcts.reform.cwrdapi.CaseWorkerRefApiApplication'


### PR DESCRIPTION
### JIRA link  ###

https://tools.hmcts.net/jira/browse/RDCC-3820

### Change description ###

upgrading log4j to 2.17.0

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
