### PR TITLE
fix: RDCC-4633 Fixed CVE CVE-2022-25647 by upgrading gson and LD

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ def versions = [
   springBoot         : '2.4.9',
   springfoxSwagger   : '2.9.2',
   pact_version       : '4.1.7',
-  launchDarklySdk    : "5.2.2",
+  launchDarklySdk    : "5.8.1",
   restAssured        : '4.3.3',
   jackson            : '2.13.1',
   log4j              : '2.17.1'
@@ -383,7 +383,7 @@ dependencies {
 
   implementation group: 'com.azure', name: 'azure-core', version: '1.13.0'
   implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.0.2'
-  implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
+  implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.9'
   implementation group: 'org.springframework', name: 'spring-core', version: '5.3.19'
   implementation group: 'org.springframework', name: 'spring-beans', version: '5.3.18'
   implementation group: 'io.netty', name: 'netty-codec-dns', version: '4.1.72.Final'

--- a/build.gradle
+++ b/build.gradle
@@ -383,7 +383,7 @@ dependencies {
 
   implementation group: 'com.azure', name: 'azure-core', version: '1.13.0'
   implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.0.2'
-  implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.9'
+  implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.0'
   implementation group: 'org.springframework', name: 'spring-core', version: '5.3.19'
   implementation group: 'org.springframework', name: 'spring-beans', version: '5.3.18'
   implementation group: 'io.netty', name: 'netty-codec-dns', version: '4.1.72.Final'


### PR DESCRIPTION
### JIRA link  ###

https://tools.hmcts.net/jira/browse/RDCC-4633

### Change description ###

Fixed CVE CVE-2022-25647 by upgrading gson and LD

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
