### PR TITLE
RDCC-5261: Upgrading postgresql to 42.4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -378,7 +378,7 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-validation'
 
   implementation group: 'org.flywaydb', name: 'flyway-core', version: '6.5.5'
-  implementation group: 'org.postgresql', name: 'postgresql', version: '42.3.3'
+  implementation group: 'org.postgresql', name: 'postgresql', version: '42.4.1'
 
   implementation group: 'com.google.guava', name: 'guava', version: '31.1-jre'
   implementation group: 'javax.el', name: 'javax.el-api', version: '3.0.0'


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-5261

### Change description ###

Upgrading `postgresql` to `42.4.1` to fix `CVE-2022-31197`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
