### PR TITLE
RDCC-4051: Fix CVE-2021-43797 for Netty

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -14,10 +14,6 @@
     <packageUrl regex="true">^pkg:maven/com\.nimbusds/lang\-tag@.*$</packageUrl>
     <cve>CVE-2020-23171</cve>
   </suppress>
-  <suppress until="2023-05-16">
-    <packageUrl regex="true">^pkg:maven/io\.netty.*$</packageUrl>
-    <cve>CVE-2021-43797</cve>
-  </suppress>
   <suppress until="2023-09-24">
     <packageUrl regex="true">^pkg:maven/org\.apache\.poi.*$</packageUrl>
     <cve>CVE-2022-26336</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-4051

### Change description ###

Fix CVE-2021-43797 for Netty

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
