### PR TITLE
RDCC-5778: Upgrading `tomcat` to version `9.0.68`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -391,9 +391,6 @@ dependencies {
   implementation group: 'org.apache.logging.log4j', name: 'log4j', version: versions.log4j
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: versions.log4j
 
-  // https://mvnrepository.com/artifact/org.apache.tomcat.embed/tomcat-embed-el
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-el', version: '9.0.63'
-
   implementation group: 'com.azure', name: 'azure-core', version: '1.13.0'
   implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.0.2'
   implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.0'
@@ -513,6 +510,7 @@ dependencyManagement {
     // CVE-2021-42340
     dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.68') {
       entry 'tomcat-embed-core'
+      entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -391,6 +391,9 @@ dependencies {
   implementation group: 'org.apache.logging.log4j', name: 'log4j', version: versions.log4j
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: versions.log4j
 
+  // https://mvnrepository.com/artifact/org.apache.tomcat.embed/tomcat-embed-el
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-el', version: '9.0.63'
+
   implementation group: 'com.azure', name: 'azure-core', version: '1.13.0'
   implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.0.2'
   implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.0'
@@ -510,7 +513,6 @@ dependencyManagement {
     // CVE-2021-42340
     dependencySet(group: 'org.apache.tomcat.embed', version: '10.1.1') {
       entry 'tomcat-embed-core'
-      entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -508,7 +508,7 @@ dependencyManagement {
 
   dependencies {
     // CVE-2021-42340
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.63') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '10.1.1') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'

--- a/build.gradle
+++ b/build.gradle
@@ -511,7 +511,7 @@ dependencyManagement {
 
   dependencies {
     // CVE-2021-42340
-    dependencySet(group: 'org.apache.tomcat.embed', version: '10.1.1') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.68') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-websocket'
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-5778

### Change description ###

Upgrading `tomcat` to version `9.0.68` to fix CVE-2022-42252

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
