### PR TITLE
RDCC-6061: Adding Suppression for `CVE-2022-41881`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -553,7 +553,7 @@ configurations.all {
   resolutionStrategy.eachDependency { details ->
     if (details.requested.group == 'io.netty'
             && details.requested.name != 'netty-tcnative-boringssl-static' ) {
-      details.useVersion "4.1.86.Final"
+      details.useVersion "4.1.77.Final"
     }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -553,7 +553,7 @@ configurations.all {
   resolutionStrategy.eachDependency { details ->
     if (details.requested.group == 'io.netty'
             && details.requested.name != 'netty-tcnative-boringssl-static' ) {
-      details.useVersion "4.1.77.Final"
+      details.useVersion "4.1.86.Final"
     }
   }
 }

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -38,4 +38,11 @@
     <cve>CVE-2022-42004</cve>
     <cve>CVE-2021-37533</cve>
   </suppress>
+  <suppress until="2024-01-01">
+    <notes><![CDATA[
+   netty 4.1.85
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.netty/netty-.+@.*$</packageUrl>
+    <cve>CVE-2022-41881</cve>
+</suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-6061

### Change description ###

Adding Suppression for `CVE-2022-41881` as latest version of netty still contains CVE.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
