### PR TITLE
RDCC-6139: Upgrading Tomcat to `9.0.69` to fix `CVE-2022-45143`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -517,7 +517,7 @@ dependencyManagement {
 
   dependencies {
     // CVE-2021-42340
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.68') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.60') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ def versions = [
   reformLogging      : '5.1.9',
   serenity           : '2.0.76',
   sonarPitest        : '0.5',
-  springBoot         : '2.6.6',
+  springBoot         : '2.6.7',
   springfoxSwagger   : '2.9.2',
   pact_version       : '4.1.7',
   launchDarklySdk    : "5.10.2",
@@ -517,7 +517,7 @@ dependencyManagement {
 
   dependencies {
     // CVE-2021-42340
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.60') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.69') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ def versions = [
   reformLogging      : '5.1.9',
   serenity           : '2.0.76',
   sonarPitest        : '0.5',
-  springBoot         : '2.6.7',
+  springBoot         : '2.6.6',
   springfoxSwagger   : '2.9.2',
   pact_version       : '4.1.7',
   launchDarklySdk    : "5.10.2",


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-6139

### Change description ###

Upgrading Tomcat to `9.0.69` to fix `CVE-2022-45143`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
