### PR TITLE
wrapping 500 error while updating user in to a proper downstream error

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/cwrdapi/UpdateStaffReferenceProfileTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/cwrdapi/UpdateStaffReferenceProfileTest.java
@@ -442,6 +442,23 @@ public class UpdateStaffReferenceProfileTest extends AuthorizationEnabledIntegra
     }
 
     @Test
+    void should_return_reinvite_staff_user_with_status_code_500_profile() throws Exception {
+
+        StaffProfileCreationRequest request = caseWorkerReferenceDataClient.createStaffProfileCreationRequest();
+        userProfilePostUserWireMockForStaffProfile(HttpStatus.INTERNAL_SERVER_ERROR);
+        request.setResendInvite(true);
+
+        Map<String, Object> createResponse = caseworkerReferenceDataClient.createStaffProfile(request,ROLE_STAFF_ADMIN);
+        Map createBody = (Map)createResponse.get("body");
+        Map<String, Object> resendResponse = caseworkerReferenceDataClient.updateStaffProfile(request,ROLE_STAFF_ADMIN);
+
+        assertThat(resendResponse).isNotNull();
+        assertThat(resendResponse.get("http_status")).isEqualTo("200 OK");
+        Map resendResponseBody = (Map) resendResponse.get("body");
+        assertEquals(createBody.get("case_worker_id"), resendResponseBody.get("case_worker_id"));
+    }
+
+    @Test
     void should_update_IdamId_when_reinvite_staff_user_true_in_crd() throws Exception {
 
         StaffProfileCreationRequest request = caseWorkerReferenceDataClient.createStaffProfileCreationRequest();

--- a/src/main/java/uk/gov/hmcts/reform/cwrdapi/service/impl/StaffRefDataServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/cwrdapi/service/impl/StaffRefDataServiceImpl.java
@@ -686,10 +686,9 @@ public class StaffRefDataServiceImpl implements StaffRefDataService {
                     PROFILE_NOT_PRESENT_IN_SRD);
         }
         ResponseEntity<Object> responseEntity = createUserProfileInIdamUP(profileRequest);
-        UserProfileCreationResponse upResponse = (UserProfileCreationResponse) (responseEntity.getBody());
-
-        // update idamid in case its different in idam
-        if (upResponse != null && !upResponse.getIdamId().equals(caseWorkerProfile.getCaseWorkerId())) {
+        if (responseEntity.getBody() != null && responseEntity.getBody() instanceof UserProfileCreationResponse
+                upResponse && !upResponse.getIdamId().equals(caseWorkerProfile.getCaseWorkerId())) {
+            // update idamid in case its different in idam
             caseWorkerProfileRepo.delete(caseWorkerProfile);
             cwrCommonRepository.flush();
             caseWorkerProfile.setCaseWorkerId(upResponse.getIdamId());
@@ -698,6 +697,10 @@ public class StaffRefDataServiceImpl implements StaffRefDataService {
             caseWorkerProfile.getCaseWorkerWorkAreas().forEach(e -> e.setCaseWorkerId(upResponse.getIdamId()));
             caseWorkerProfile.getCaseWorkerSkills().forEach(e -> e.setCaseWorkerId(upResponse.getIdamId()));
             caseWorkerProfileRepo.save(caseWorkerProfile);
+        } else {
+            ErrorResponse error = (ErrorResponse) responseEntity.getBody();
+            throw new StaffReferenceException(responseEntity.getStatusCode(), error.getErrorMessage(),
+                    error.getErrorDescription());
         }
         return new StaffProfileCreationResponse(caseWorkerProfile.getCaseWorkerId());
     }


### PR DESCRIPTION
Wrapping 500 error while reinvite user to a proper response

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
