### PR TITLE
Nightly build failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -519,7 +519,7 @@ dependencyManagement {
 
   dependencies {
     // CVE-2021-42340
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.71') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.72') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'


### PR DESCRIPTION


### JIRA link (if applicable) ###



### Change description ###

Addresses CVE-2023-28708

Remedied in Tomcat 9.0.72 - https://tomcat.apache.org/security-9.html#Fixed_in_Apache_Tomcat_9.0.72

CVE found in https://static-build.platform.hmcts.net/static-files/WY9YElWyRTMnNXrF0JpKKVEESSPkgBJYx3ELIsaEsvQxNjgwMDc5NDM5NjI5OjI0Okx1a2Fzei5Xb2xza2kxQEhNQ1RTLk5FVDp2aWV3L1JEL2pvYi9ITUNUU19qX3RvX3pfTmlnaHRseS9qb2IvcmQtY2FzZXdvcmtlci1yZWYtYXBpL2pvYi9tYXN0ZXIvNDI5L2FydGlmYWN0/build/reports/dependency-check-report.html

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
