### PR TITLE
Upped spring framework version to fix CVE-2023-20860

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ def versions = [
   restAssured        : '4.3.3',
   jackson            : '2.14.2',
   log4j              : '2.17.1',
-  springVersion      : '5.3.20',
+  springVersion      : '5.3.26',
   poi                : '4.1.2',
   logback            : '1.2.11',
   testContainer_postgresql: '1.17.6'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -18,7 +18,4 @@ file name: launchdarkly-java-server-sdk-5.10.2.jar (shaded: org.yaml:snakeyaml:1
    <suppress>
      <cve>CVE-2023-20861</cve>
    </suppress>
-   <suppress>
-     <cve>CVE-2023-20860</cve>
-   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
[
](https://tools.hmcts.net/jira/browse/DTSRD-151)

### Change description ###
Upped spring framework to a version that doesn't have the vulnerability
https://nvd.nist.gov/vuln/detail/CVE-2023-20860 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
