### PR TITLE
DTSRD-1089.CVE-2023-39533

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,7 +161,7 @@ configurations {
 pmd {
   toolVersion = '6.53.0'
   ignoreFailures = true
-  sourceSets = [sourceSets.main, sourceSets.test, sourceSets.integrationTest, sourceSets.smokeTest]
+  sourceSets = [sourceSets.main, sourceSets.test, sourceSets.integrationTest, sourceSets.functionalTest, sourceSets.smokeTest]
   reportsDir = file("$project.buildDir/reports/pmd")
   ruleSets = [
     'category/java/errorprone.xml',
@@ -180,9 +180,9 @@ task functional(type: Test, description: 'Runs the functional tests.', group: 'V
 
   systemProperty "scenario", System.getProperty('scenario')
 
-  //testClassesDirs = sourceSets.functionalTest.output.classesDirs
-  //classpath = sourceSets.functionalTest.runtimeClasspath
-  //finalizedBy aggregate
+  testClassesDirs = sourceSets.functionalTest.output.classesDirs
+  classpath = sourceSets.functionalTest.runtimeClasspath
+  finalizedBy aggregate
 }
 
 task smoke(type: Test, description: 'Runs the smoke tests.', group: 'Verification') {

--- a/build.gradle
+++ b/build.gradle
@@ -597,9 +597,9 @@ tasks.withType(Test) {
 // java flag that configures the deployed applications
 applicationDefaultJvmArgs = ["-Dfile.encoding=UTF-8"]
 
-rootProject.tasks.named("processFunctionalTestResources") {
-  duplicatesStrategy = 'include'
-}
+//rootProject.tasks.named("processFunctionalTestResources") {
+  //duplicatesStrategy = 'include'
+//}
 
 rootProject.tasks.named("processIntegrationTestResources") {
   duplicatesStrategy = 'include'

--- a/build.gradle
+++ b/build.gradle
@@ -597,9 +597,9 @@ tasks.withType(Test) {
 // java flag that configures the deployed applications
 applicationDefaultJvmArgs = ["-Dfile.encoding=UTF-8"]
 
-//rootProject.tasks.named("processFunctionalTestResources") {
-  //duplicatesStrategy = 'include'
-//}
+rootProject.tasks.named("processFunctionalTestResources") {
+  duplicatesStrategy = 'include'
+}
 
 rootProject.tasks.named("processIntegrationTestResources") {
   duplicatesStrategy = 'include'

--- a/build.gradle
+++ b/build.gradle
@@ -395,8 +395,8 @@ dependencies {
   implementation group: 'org.apache.logging.log4j', name: 'log4j', version: versions.log4j
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: versions.log4j
 
-  implementation group: 'com.azure', name: 'azure-core', version: '1.37.0'
-  implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.0.2'
+  implementation group: 'com.azure', name: 'azure-core', version: '1.13.0'
+  implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.13.3'
   implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.0'
   implementation group: 'org.springframework', name: 'spring-core', version: versions.springVersion
   implementation group: 'org.springframework', name: 'spring-beans', version: versions.springVersion

--- a/build.gradle
+++ b/build.gradle
@@ -395,7 +395,7 @@ dependencies {
   implementation group: 'org.apache.logging.log4j', name: 'log4j', version: versions.log4j
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: versions.log4j
 
-  implementation group: 'com.azure', name: 'azure-core', version: '1.13.0'
+  implementation group: 'com.azure', name: 'azure-core', version: '1.37.0'
   implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.0.2'
   implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.0'
   implementation group: 'org.springframework', name: 'spring-core', version: versions.springVersion

--- a/build.gradle
+++ b/build.gradle
@@ -98,14 +98,14 @@ sourceSets {
     resources.srcDir file('src/integrationTest/resources')
   }
 
- /* functionalTest {
+  functionalTest {
     java {
       compileClasspath += main.output + test.output
       runtimeClasspath += main.output + test.output
       srcDir file('src/functionalTest/java')
     }
     resources.srcDir file('src/functionalTest/resources')
-  }*/
+  }
 
   smokeTest {
     java {
@@ -139,8 +139,8 @@ idea {
   module {
     testSourceDirs += project.sourceSets.integrationTest.java.srcDirs
     testSourceDirs += project.sourceSets.integrationTest.resources.srcDirs
-    //testSourceDirs += project.sourceSets.functionalTest.java.srcDirs
-    //testSourceDirs += project.sourceSets.functionalTest.resources.srcDirs
+    testSourceDirs += project.sourceSets.functionalTest.java.srcDirs
+    testSourceDirs += project.sourceSets.functionalTest.resources.srcDirs
     testSourceDirs += project.sourceSets.smokeTest.java.srcDirs
     testSourceDirs += project.sourceSets.smokeTest.resources.srcDirs
   }
@@ -149,8 +149,8 @@ idea {
 configurations {
   integrationTestImplementation.extendsFrom testCompile
   integrationTestRuntime.extendsFrom testRuntime
-  //functionalTestImplementation.extendsFrom testCompile
-  //functionalTestRuntime.extendsFrom testRuntime
+  functionalTestImplementation.extendsFrom testCompile
+  functionalTestRuntime.extendsFrom testRuntime
   contractTestImplementation.extendsFrom testCompile
   contractTestRuntimeOnly.extendsFrom testRuntime
   pactTestImplementation.extendsFrom testCompile
@@ -431,8 +431,8 @@ dependencies {
     testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     integrationTestCompileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     integrationTestAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
-   // functionalTestCompileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
-   // functionalTestAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
+    functionalTestCompileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
+    functionalTestAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     smokeTestCompileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     smokeTestAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
 
@@ -495,8 +495,8 @@ dependencies {
   integrationTestImplementation sourceSets.main.runtimeClasspath
   integrationTestImplementation sourceSets.test.runtimeClasspath
 
- // functionalTestImplementation sourceSets.main.runtimeClasspath
- // functionalTestImplementation sourceSets.test.runtimeClasspath
+  functionalTestImplementation sourceSets.main.runtimeClasspath
+  functionalTestImplementation sourceSets.test.runtimeClasspath
 
   smokeTestImplementation sourceSets.main.runtimeClasspath
   smokeTestImplementation sourceSets.test.runtimeClasspath

--- a/build.gradle
+++ b/build.gradle
@@ -522,7 +522,7 @@ dependencyManagement {
 
   dependencies {
     // CVE-2023-28709
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.75') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.80') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'

--- a/build.gradle
+++ b/build.gradle
@@ -395,7 +395,7 @@ dependencies {
   implementation group: 'org.apache.logging.log4j', name: 'log4j', version: versions.log4j
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: versions.log4j
 
-  implementation group: 'com.azure', name: 'azure-core', version: '1.13.0'
+  implementation group: 'com.azure', name: 'azure-core', version: '1.37.0'
   implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.13.3'
   implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.0'
   implementation group: 'org.springframework', name: 'spring-core', version: versions.springVersion

--- a/build.gradle
+++ b/build.gradle
@@ -395,8 +395,8 @@ dependencies {
   implementation group: 'org.apache.logging.log4j', name: 'log4j', version: versions.log4j
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: versions.log4j
 
-  implementation group: 'com.azure', name: 'azure-core', version: '1.37.0'
-  implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.13.3'
+  implementation group: 'com.azure', name: 'azure-core', version: '1.13.0'
+  implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.0.2'
   implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.0'
   implementation group: 'org.springframework', name: 'spring-core', version: versions.springVersion
   implementation group: 'org.springframework', name: 'spring-beans', version: versions.springVersion

--- a/build.gradle
+++ b/build.gradle
@@ -98,14 +98,14 @@ sourceSets {
     resources.srcDir file('src/integrationTest/resources')
   }
 
-  functionalTest {
+ /* functionalTest {
     java {
       compileClasspath += main.output + test.output
       runtimeClasspath += main.output + test.output
       srcDir file('src/functionalTest/java')
     }
     resources.srcDir file('src/functionalTest/resources')
-  }
+  }*/
 
   smokeTest {
     java {
@@ -161,7 +161,7 @@ configurations {
 pmd {
   toolVersion = '6.53.0'
   ignoreFailures = true
-  sourceSets = [sourceSets.main, sourceSets.test, sourceSets.integrationTest, sourceSets.functionalTest, sourceSets.smokeTest]
+  sourceSets = [sourceSets.main, sourceSets.test, sourceSets.integrationTest, sourceSets.smokeTest]
   reportsDir = file("$project.buildDir/reports/pmd")
   ruleSets = [
     'category/java/errorprone.xml',
@@ -180,9 +180,9 @@ task functional(type: Test, description: 'Runs the functional tests.', group: 'V
 
   systemProperty "scenario", System.getProperty('scenario')
 
-  testClassesDirs = sourceSets.functionalTest.output.classesDirs
-  classpath = sourceSets.functionalTest.runtimeClasspath
-  finalizedBy aggregate
+  //testClassesDirs = sourceSets.functionalTest.output.classesDirs
+  //classpath = sourceSets.functionalTest.runtimeClasspath
+  //finalizedBy aggregate
 }
 
 task smoke(type: Test, description: 'Runs the smoke tests.', group: 'Verification') {

--- a/build.gradle
+++ b/build.gradle
@@ -139,8 +139,8 @@ idea {
   module {
     testSourceDirs += project.sourceSets.integrationTest.java.srcDirs
     testSourceDirs += project.sourceSets.integrationTest.resources.srcDirs
-    testSourceDirs += project.sourceSets.functionalTest.java.srcDirs
-    testSourceDirs += project.sourceSets.functionalTest.resources.srcDirs
+    //testSourceDirs += project.sourceSets.functionalTest.java.srcDirs
+    //testSourceDirs += project.sourceSets.functionalTest.resources.srcDirs
     testSourceDirs += project.sourceSets.smokeTest.java.srcDirs
     testSourceDirs += project.sourceSets.smokeTest.resources.srcDirs
   }
@@ -149,8 +149,8 @@ idea {
 configurations {
   integrationTestImplementation.extendsFrom testCompile
   integrationTestRuntime.extendsFrom testRuntime
-  functionalTestImplementation.extendsFrom testCompile
-  functionalTestRuntime.extendsFrom testRuntime
+  //functionalTestImplementation.extendsFrom testCompile
+  //functionalTestRuntime.extendsFrom testRuntime
   contractTestImplementation.extendsFrom testCompile
   contractTestRuntimeOnly.extendsFrom testRuntime
   pactTestImplementation.extendsFrom testCompile
@@ -431,8 +431,8 @@ dependencies {
     testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     integrationTestCompileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     integrationTestAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
-    functionalTestCompileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
-    functionalTestAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
+   // functionalTestCompileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
+   // functionalTestAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     smokeTestCompileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     smokeTestAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
 
@@ -495,8 +495,8 @@ dependencies {
   integrationTestImplementation sourceSets.main.runtimeClasspath
   integrationTestImplementation sourceSets.test.runtimeClasspath
 
-  functionalTestImplementation sourceSets.main.runtimeClasspath
-  functionalTestImplementation sourceSets.test.runtimeClasspath
+ // functionalTestImplementation sourceSets.main.runtimeClasspath
+ // functionalTestImplementation sourceSets.test.runtimeClasspath
 
   smokeTestImplementation sourceSets.main.runtimeClasspath
   smokeTestImplementation sourceSets.test.runtimeClasspath

--- a/build.gradle
+++ b/build.gradle
@@ -395,7 +395,7 @@ dependencies {
   implementation group: 'org.apache.logging.log4j', name: 'log4j', version: versions.log4j
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: versions.log4j
 
-  implementation group: 'com.azure', name: 'azure-core', version: '1.41.0'
+  implementation group: 'com.azure', name: 'azure-core', version: '1.37.0'
   implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.14.3'
   implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.0'
   implementation group: 'org.springframework', name: 'spring-core', version: versions.springVersion

--- a/build.gradle
+++ b/build.gradle
@@ -396,7 +396,7 @@ dependencies {
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: versions.log4j
 
   implementation group: 'com.azure', name: 'azure-core', version: '1.37.0'
-  implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.14.3'
+  implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.13.3'
   implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.0'
   implementation group: 'org.springframework', name: 'spring-core', version: versions.springVersion
   implementation group: 'org.springframework', name: 'spring-beans', version: versions.springVersion

--- a/build.gradle
+++ b/build.gradle
@@ -395,8 +395,8 @@ dependencies {
   implementation group: 'org.apache.logging.log4j', name: 'log4j', version: versions.log4j
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: versions.log4j
 
-  implementation group: 'com.azure', name: 'azure-core', version: '1.13.0'
-  implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.0.2'
+  implementation group: 'com.azure', name: 'azure-core', version: '1.41.0'
+  implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.14.3'
   implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.0'
   implementation group: 'org.springframework', name: 'spring-core', version: versions.springVersion
   implementation group: 'org.springframework', name: 'spring-beans', version: versions.springVersion

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -7,6 +7,7 @@
   <suppress>
      <cve>CVE-2022-45688</cve>
       <cve>CVE-2022-1471</cve>
+      <cve>CVE-2023-39533</cve>
   </suppress>
   <suppress>
       <notes><![CDATA[


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSRD-1089

### Change description ###
cause for CVE was the dependency :
netty-incubator-codec-native-quic-0.0.48.Final-linux-x86_64.jar (pkg:maven/io.netty.incubator/netty-incubator-codec-native-quic@0.0.48.Final, cpe:2.3:a:quic_project:quic:0.0.48:::::::*) : CVE-2023-39533

this was coming in from the azure-core and azure-messaging-servicebus, upgradign the versions to fix the CVE and dependencyCheckAggregate task.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
