### PR TITLE
DTSRD-1456

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -540,6 +540,30 @@ dependencyManagement {
       entry 'spring-cloud-starter-openfeign'
       entry 'spring-cloud-openfeign-core'
     }
+
+
+    //        Resolves CVE-2023-4586
+    dependencySet(group: 'io.netty', version: '4.1.100.Final') {
+      entry 'netty-buffer'
+      entry 'netty-codec'
+      entry 'netty-codec-dns'
+      entry 'netty-codec-http'
+      entry 'netty-codec-http2'
+      entry 'netty-codec-socks'
+      entry 'netty-common'
+      entry 'netty-handler'
+      entry 'netty-handler-proxy'
+      entry 'netty-resolver'
+      entry 'netty-resolver-dns'
+      entry 'netty-resolver-dns-classes-macos'
+      entry 'netty-resolver-dns-native-macos'
+      entry 'netty-transport'
+      entry 'netty-transport-classes-epoll'
+      entry 'netty-transport-classes-kqueue'
+      entry 'netty-transport-native-epoll'
+      entry 'netty-transport-native-kqueue'
+      entry 'netty-transport-native-unix-common'
+    }
   }
 }
 
@@ -566,20 +590,6 @@ bootJar {
   archiveFileName = jarName
   manifest {
     attributes('Implementation-Version': project.version.toString())
-  }
-}
-configurations.all {
-  resolutionStrategy.eachDependency { details ->
-//    added netty-tcnative-boringssl-static because its required for
-//    group: 'com.azure', name: 'azure-core', version: '1.13.0' in spring boot upgrade
-    if (details.requested.group == 'io.netty'
-            && details.requested.name == 'netty-tcnative-boringssl-static' ){
-      details.useVersion "2.0.35.Final"
-    }
-    if (details.requested.group == 'io.netty'
-            && details.requested.name != 'netty-tcnative-boringssl-static' ) {
-      details.useVersion "4.1.94.Final"
-    }
   }
 }
 

--- a/charts/rd-caseworker-ref-api/Chart.yaml
+++ b/charts/rd-caseworker-ref-api/Chart.yaml
@@ -3,12 +3,12 @@ appVersion: "1.0"
 description: A Helm chart for rd-caseworker-ref-api
 name: rd-caseworker-ref-api
 home: https://github.com/hmcts/rd-caseworker-ref-api
-version: 1.0.2
+version: 1.0.3
 maintainers:
   - name: Reference Data Team
 dependencies:
   - name: java
-    version: 4.2.0
+    version: 5.0.0
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
   - name: servicebus
     version: 1.0.4


### PR DESCRIPTION
- Updating Netty versions for CVE-2023-4586.
- Updating helm version; Version of java helm chart below 5.0.0 is deprecated, please upgrade to latest release https://github.com/hmcts/chart-java/releases This configuration will stop working by 23/10/2023

**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSRD-1456

### Change description ###

DTSRD-1456

- Updating Netty versions for CVE-2023-4586.
- Updating helm version; Version of java helm chart below 5.0.0 is deprecated, please upgrade to latest release https://github.com/hmcts/chart-java/releases This configuration will stop working by 23/10/2023

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
