### PR TITLE
DTSRD-3580 Jenkins Test Reports to Publish on Failure - afterSuccess(…

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -79,31 +79,31 @@ withPipeline(type, product, component) {
     syncBranchesWithMaster(branchesToSync)
 
 
-    afterSuccess('integrationTest:preview') {
+    afterAlways('integrationTest:preview') {
      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
     }
 
-    afterSuccess('integrationTest:aat') {
+    afterAlways('integrationTest:aat') {
      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
     }
 
-    afterSuccess('functionalTest:preview') {
+    afterAlways('functionalTest:preview') {
         steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
     }
 
-    afterSuccess('functionalTest:aat') {
+    afterAlways('functionalTest:aat') {
         steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
     }
 
-    afterSuccess('pact-provider-verification') {
+    afterAlways('pact-provider-verification') {
         steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/tests/**/*'
     }
 
-    afterSuccess('pact-consumer-tests') {
+    afterAlways('pact-consumer-tests') {
         steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/tests/**/*'
     }
 
-    afterSuccess('sonarscan') {
+    afterAlways('sonarscan') {
         publishHTML target: [
             allowMissing         : true,
             alwaysLinkToLastBuild: true,
@@ -123,7 +123,7 @@ withPipeline(type, product, component) {
         ]
     }
 
-    afterSuccess('smoketest:preview') {
+    afterAlways('smoketest:preview') {
         publishHTML target: [
             allowMissing         : true,
             alwaysLinkToLastBuild: true,
@@ -134,7 +134,7 @@ withPipeline(type, product, component) {
         ]
     }
 
-    afterSuccess('smoketest:aat') {
+    afterAlways('smoketest:aat') {
         publishHTML target: [
             allowMissing         : true,
             alwaysLinkToLastBuild: true,
@@ -145,7 +145,7 @@ withPipeline(type, product, component) {
         ]
     }
 
-    afterSuccess('functionalTest:aat') {
+    afterAlways('functionalTest:aat') {
         steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
         publishHTML target: [
             allowMissing         : true,
@@ -157,7 +157,7 @@ withPipeline(type, product, component) {
         ]
     }
 
-    afterSuccess('functionalTest:preview') {
+    afterAlways('functionalTest:preview') {
         steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
         publishHTML target: [
             allowMissing         : true,
@@ -169,7 +169,7 @@ withPipeline(type, product, component) {
         ]
     }
 
-    afterSuccess('pact-provider-verification') {
+    afterAlways('pact-provider-verification') {
         publishHTML target: [
              allowMissing         : true,
              alwaysLinkToLastBuild: true,
@@ -181,7 +181,7 @@ withPipeline(type, product, component) {
         steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/tests/**/*'
     }
 
-    afterSuccess('pact-consumer-tests') {
+    afterAlways('pact-consumer-tests') {
             publishHTML target: [
                  allowMissing         : true,
                  alwaysLinkToLastBuild: true,

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -76,7 +76,7 @@ withNightlyPipeline(type, product, component) {
   enableSecurityScan()
   enableFortifyScan()
 
-  afterSuccess('fullFunctionalTest') {
+  afterAlways('fullFunctionalTest') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/**/*'
 
@@ -98,7 +98,7 @@ withNightlyPipeline(type, product, component) {
     print "completed delete script for nightly"
   }
 
-  afterSuccess('mutationTest') {
+  afterAlways('mutationTest') {
     publishHTML target: [
             allowMissing         : true,
             alwaysLinkToLastBuild: true,


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSRD-3580

### Change description ###
Jenkins Test Reports to Publish on Failure - afterSuccess() replaced with afterAlways() for all reports in Jenkinsfile_CNP and nightly

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
