### PR TITLE
CME-247: Disable sync to ITHC for database monitoring testing

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -35,7 +35,7 @@ def vaultOverrides = [
 ]
 
 // Configure branches to sync with master branch
-def branchesToSync = ['demo', 'ithc', 'perftest']
+def branchesToSync = ['demo', 'perftest']
 
 // Var for testcontainers.org
 env.TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX = "hmctspublic.azurecr.io/imported/"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CME-247


### Change description ###
Changes for https://github.com/hmcts/rd-caseworker-ref-api/pull/992 needs to be tested in ITHC.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
