### PR TITLE
Create lombok.config

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.copyJacksonAnnotationsToAccessors = true


### PR DESCRIPTION
### Change description ###

Addresses breaking change (from Lombok changeling):
BREAKING CHANGE: From versions 1.18.16 to 1.18.38, lombok automatically copies certain Jackson annotations (e.g., @JsonProperty) from fields to the corresponding accessors (getters/setters). However, it turned out to be harmful in certain situations. Thus, Lombok does not automatically copy those annotations any more. You can restore the old behavior using the [config key](https://projectlombok.org/features/configuration) lombok.copyJacksonAnnotationsToAccessors = true.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
